### PR TITLE
Various lints

### DIFF
--- a/src/custom_error.rs
+++ b/src/custom_error.rs
@@ -141,7 +141,7 @@ pub fn other_io_err(descr: &'static str, detail: Option<String>,
 }
 
 /// maps a `ParseIntError` to an `Error`
-pub fn pie2error(p: num::ParseIntError) -> RustyError {
+pub fn pie2error(p: &num::ParseIntError) -> RustyError {
     RustyError::new("Integer parsing error", Some(p.to_string()), None, None)
 }
 
@@ -175,7 +175,7 @@ mod tests_std_err {
     #[test]
     fn test_parse_errors() {
         let nan = "2a".to_string();
-        match nan.parse::<u8>().map_err(pie2error) {
+        match nan.parse::<u8>().map_err(|err| pie2error(&err)) {
             Ok(_) => assert!(false),
             Err(x) => assert_eq!("Integer parsing error", x.description()),
         }

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -30,7 +30,7 @@ pub fn lagrange_interpolate(src: &[(u8, u8)]) -> u8 {
             if i != j {
                 let xj = Gf256::from_byte(raw_xj);
                 let delta = xi - xj;
-                assert!(delta.poly != 0, "Duplicate shares");
+                assert_ne!(delta.poly, 0, "Duplicate shares");
                 prod = prod * xj / delta;
             }
         }

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -12,7 +12,7 @@ pub fn encode<W: Write>(src: &[u8], n: u8, w: &mut W) -> io::Result<()> {
             acc = acc + fac * Gf256::from_byte(coeff);
             fac = fac * x;
         }
-        try!(w.write(&[acc.to_byte()]));
+        try!(w.write_all(&[acc.to_byte()]));
     }
     Ok(())
 }

--- a/src/share_format.rs
+++ b/src/share_format.rs
@@ -43,8 +43,8 @@ pub fn share_from_string
     }
     let (k, n, p3) = {
         let mut iter = parts.into_iter();
-        let k = try!(iter.next().unwrap().parse::<u8>().map_err(pie2error));
-        let n = try!(iter.next().unwrap().parse::<u8>().map_err(pie2error));
+        let k = try!(iter.next().unwrap().parse::<u8>().map_err(|err| pie2error(&err)));
+        let n = try!(iter.next().unwrap().parse::<u8>().map_err(|err| pie2error(&err)));
         let p3 = iter.next().unwrap();
         (k, n, p3)
     };

--- a/src/sss.rs
+++ b/src/sss.rs
@@ -101,7 +101,7 @@ fn secret_share(src: &[u8], k: u8, n: u8) -> Result<Vec<Vec<u8>>, RustyError> {
 /// let share2 = "2-4-ChaydsUJDypD9ZWxwvIICh/cmZvzusOF".to_string();
 /// let shares = vec![share1, share2];
 ///
-/// match recover_secret(shares, false) {
+/// match recover_secret(&shares, false) {
 /// 	Ok(secret) => {
 /// 		// Do something with the secret
 /// 	},
@@ -110,7 +110,7 @@ fn secret_share(src: &[u8], k: u8, n: u8) -> Result<Vec<Vec<u8>>, RustyError> {
 /// 	}
 /// }
 /// ```
-pub fn recover_secret(shares: Vec<String>, verify_signatures: bool) -> Result<Vec<u8>, RustyError> {
+pub fn recover_secret(shares: &[String], verify_signatures: bool) -> Result<Vec<u8>, RustyError> {
     let (k, shares) = try!(process_and_validate_shares(shares, verify_signatures));
 
     let slen = shares[0].1.len();

--- a/src/tests/test_vectors.rs
+++ b/src/tests/test_vectors.rs
@@ -29,7 +29,7 @@ fn test_recover_sellibitze() {
 
     let mut secret = "My secret".to_string().into_bytes();
     secret.push(10);
-    assert_eq!(recover_secret(shares, false).unwrap(), secret);
+    assert_eq!(recover_secret(&shares, false).unwrap(), secret);
 }
 
 // Generated with code on master branch on the 6th of April.
@@ -58,7 +58,7 @@ fn test_recover_es_test_vectors() {
 
     let secret =
         "The immoral cannot be made moral through the use of secret law.".to_string().into_bytes();
-    assert_eq!(recover_secret(shares, false).unwrap(), secret);
+    assert_eq!(recover_secret(&shares, false).unwrap(), secret);
 }
 
 #[test]
@@ -75,5 +75,5 @@ fn test_recover_sellibitze_more_than_threshold_shars() {
 
     let mut secret = "My secret".to_string().into_bytes();
     secret.push(10);
-    assert_eq!(recover_secret(shares, false).unwrap(), secret);
+    assert_eq!(recover_secret(&shares, false).unwrap(), secret);
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -13,7 +13,7 @@ type ProcessedShares = Result<(u8, Vec<(u8, Vec<u8>)>), RustyError>;
 // 2) Validate group consistency
 // 3) Validate other properties, in no specific order
 
-pub fn process_and_validate_shares(shares_strings: Vec<String>,
+pub fn process_and_validate_shares(shares_strings: &[String],
                                    verify_signatures: bool)
                                    -> ProcessedShares {
     let mut shares: Vec<(u8, Vec<u8>)> = Vec::new();
@@ -36,7 +36,7 @@ pub fn process_and_validate_shares(shares_strings: Vec<String>,
 
             try!(verify_data_vec_signature(format_share_for_signing(k,
                                                                     n,
-                                                                    &share_data.as_slice()),
+                                                                    &share_data),
                                                                     &(signature.to_vec(), p),
                                                                     &root_hash)
 		    .map_err(|e| RustyError::with_type(RustyErrorTypes::InvalidSignature(share_index, String::from(e.description())))));

--- a/src/wrapped_secrets.rs
+++ b/src/wrapped_secrets.rs
@@ -47,7 +47,7 @@ pub fn generate_shares(k: u8, n: u8, secret: &[u8], mime_type: Option<String>, s
 /// let share2 = "2-4-ChaydsUJDypD9ZWxwvIICh/cmZvzusOF".to_string();
 /// let shares = vec![share1, share2];
 ///
-/// match recover_secret(shares, false) {
+/// match recover_secret(&shares, false) {
 /// 	Ok(secret) => {
 /// 		// Do something with the secret
 /// 	},
@@ -56,7 +56,7 @@ pub fn generate_shares(k: u8, n: u8, secret: &[u8], mime_type: Option<String>, s
 /// 	}
 /// }
 /// ```
-pub fn recover_secret(shares: Vec<String>, verify_signatures: bool) -> Result<RustySecret, RustyError> {
+pub fn recover_secret(shares: &[String], verify_signatures: bool) -> Result<RustySecret, RustyError> {
     let secret = try!(sss::recover_secret(shares, verify_signatures));
 
     protobuf::parse_from_bytes::<RustySecret>(secret.as_slice())

--- a/tests/randomized_tests.rs
+++ b/tests/randomized_tests.rs
@@ -22,7 +22,7 @@ fn test_reasonable_splits() {
                 let shares = wrapped_secrets::generate_shares(k, n, &secret, Some(mime_type.clone()), *is_signing).unwrap();
                 println!("Testing {} out-of- {}", k, n);
 
-                let s = wrapped_secrets::recover_secret(shares, *is_signing).unwrap();
+                let s = wrapped_secrets::recover_secret(&shares, *is_signing).unwrap();
                 assert_eq!(s.get_secret().to_owned(), secret);
                 assert!(s.has_mime_type());
                 assert_eq!(mime_type, s.get_mime_type());

--- a/tests/recovery_errors.rs
+++ b/tests/recovery_errors.rs
@@ -6,14 +6,14 @@ use rusty_secrets::sss::recover_secret;
 #[should_panic(expected = "No shares were provided.")]
 fn test_recover_no_shares() {
     let shares = vec![];
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "No shares were provided.")]
 fn test_recover_no_shares_signed() {
     let shares = vec![];
-    recover_secret(shares, true).unwrap();
+    recover_secret(&shares, true).unwrap();
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn test_recover_2_parts_share() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn test_recover_incorrect_share_num() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn test_recover_0_share_num() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn test_recover_invalid_b64() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_recover_duplicate_shares_number() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn test_recover_duplicate_shares_data() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }
 
 #[test]
@@ -90,5 +90,5 @@ fn test_recover_too_few_shares() {
 
     let shares = vec![share1, share2];
 
-    recover_secret(shares, false).unwrap();
+    recover_secret(&shares, false).unwrap();
 }


### PR DESCRIPTION
Hi,

I've added a few lints to clean up the code. Tests still pass.
The most notable change is that I have broken the public API, `recover_secret` now takes a slice rather than a Vec.

A couple more things that I didn't fix but that should be addressed:
- The protobuf method `make_repeated_bytes_accessor` is deprecated. Any reason why that is still used?
- In `wrapped_secrets.rs:31` there is a weird for loop over an `Option<String>`. Is that on purpose? What are you trying to do? I think you're better off with `if let Some(mt)`
- I didn't want to ruin the whole history and send a million lines PR, but you should really consider to format the code using `rustfmt`

One last thing, are you planning a release of the signed shares stuff?
