### PR TITLE
Fix bug where threshold did not set deg of secret polynomial

### DIFF
--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -72,7 +72,7 @@ impl SSS {
         for _ in 0..(shares_count as usize) {
             result.push(vec![0u8; src.len()]);
         }
-        let mut col_in = vec![0u8, threshold];
+        let mut col_in = vec![0u8; threshold as usize];
         let mut col_out = Vec::with_capacity(shares_count as usize);
         let mut osrng = OsRng::new()?;
         for (c, &s) in src.iter().enumerate() {


### PR DESCRIPTION
Fixes #43.

Fixes a syntactic error. Threshold should determine the number of coefficients in the secret polynomial. As is the code is equivalent to threshold always being 2.