### PR TITLE
Implement {Add, Div, Mul, Sub}Assign for Gf256

### DIFF
--- a/src/dss/thss/encode.rs
+++ b/src/dss/thss/encode.rs
@@ -31,7 +31,7 @@ pub(crate) fn encode_secret_byte(m: u8, j: u8, poly: &Poly) -> u8 {
     let mut acc = Gf256::from_byte(m);
     for (l, &r) in poly.coeffs.iter().enumerate() {
         let s = Gf256::from_byte(j).pow(l as u8 + 1);
-        acc = acc + r * s;
+        acc += r * s;
     }
     acc.to_byte()
 }

--- a/src/gf256.rs
+++ b/src/gf256.rs
@@ -1,7 +1,7 @@
 //! This module provides the Gf256 type which is used to represent
 //! elements of a finite field with 256 elements.
 
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 include!(concat!(env!("OUT_DIR"), "/nothinghardcoded.rs"));
 
@@ -74,11 +74,25 @@ impl Add<Gf256> for Gf256 {
     }
 }
 
+impl AddAssign<Gf256> for Gf256 {
+    #[inline]
+    fn add_assign(&mut self, rhs: Gf256) {
+        *self = *self + rhs;
+    }
+}
+
 impl Sub<Gf256> for Gf256 {
     type Output = Gf256;
     #[inline]
     fn sub(self, rhs: Gf256) -> Gf256 {
         Gf256::from_byte(self.poly ^ rhs.poly)
+    }
+}
+
+impl SubAssign<Gf256> for Gf256 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Gf256) {
+        *self = *self - rhs;
     }
 }
 
@@ -94,6 +108,12 @@ impl Mul<Gf256> for Gf256 {
     }
 }
 
+impl MulAssign<Gf256> for Gf256 {
+    fn mul_assign(&mut self, rhs: Gf256) {
+        *self = *self * rhs;
+    }
+}
+
 impl Div<Gf256> for Gf256 {
     type Output = Gf256;
     fn div(self, rhs: Gf256) -> Gf256 {
@@ -104,6 +124,12 @@ impl Div<Gf256> for Gf256 {
         } else {
             Gf256 { poly: 0 }
         }
+    }
+}
+
+impl DivAssign<Gf256> for Gf256 {
+    fn div_assign(&mut self, rhs: Gf256) {
+        *self = *self / rhs;
     }
 }
 

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -15,10 +15,10 @@ pub(crate) fn interpolate_at(points: &[(u8, u8)]) -> u8 {
                 let xj = Gf256::from_byte(raw_xj);
                 let delta = xi - xj;
                 assert_ne!(delta.poly, 0, "Duplicate shares");
-                prod = prod * xj / delta;
+                prod *= xj / delta;
             }
         }
-        sum = sum + prod * yi;
+        sum += prod * yi;
     }
     sum.to_byte()
 }
@@ -37,7 +37,7 @@ pub(crate) fn interpolate(points: &[(Gf256, Gf256)]) -> Poly {
         let mut prod = Gf256::one();
         for &(x1, _) in points {
             if x != x1 {
-                prod = prod * (x - x1);
+                prod *= x - x1;
 
                 let mut prec = Gf256::zero();
                 coeffs = coeffs

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -21,7 +21,7 @@ impl Poly {
         let mut result = Gf256::zero();
 
         for (i, c) in self.coeffs.iter().enumerate() {
-            result = result + *c * x.pow(i as u8);
+            result += *c * x.pow(i as u8);
         }
 
         result

--- a/src/sss/encode.rs
+++ b/src/sss/encode.rs
@@ -9,8 +9,8 @@ pub(crate) fn encode_secret_byte<W: Write>(src: &[u8], n: u8, w: &mut W) -> io::
         let mut fac = Gf256::one();
         let mut acc = Gf256::zero();
         for &coeff in src.iter() {
-            acc = acc + fac * Gf256::from_byte(coeff);
-            fac = fac * x;
+            acc += fac * Gf256::from_byte(coeff);
+            fac *= x;
         }
         w.write_all(&[acc.to_byte()])?;
     }


### PR DESCRIPTION
I implemented the `{Add, Div, Mul, Sub}Assign` because I believe they make the code cleaner and easier to follow. I didn't write any tests because the implementations are very simply piggy-backing on the code you've already written, but am happy to add some if you'd like.

I want to note that the assignment operators are not identical to the non-assignment counterparts because I didn't find any documentation on this. When using the assignment operators first the right-hand side of the `<op>=` symbol is calculated and then `<op>` operates on that and the left-hand side. So one needs to be careful order of operations are respected:

```rust
fn main() {
    let mut x = 4;
    x *= 2 + 5;
    println!("{:?}", x);

    let mut x = 4;
    x = x * 2 + 5;
    println!("{:?}", x);
}
```
```
28
13
```

This is relevant in https://github.com/SpinResearch/RustySecrets/compare/SpinResearch:3de1689...nvesely:f3f16dc#diff-6dad4b2a3f944968075fe32bae709406R40