### PR TITLE
Use Horner's method for evaluating polynomials

### DIFF
--- a/src/sss/encode.rs
+++ b/src/sss/encode.rs
@@ -3,14 +3,12 @@ use std::io;
 use std::io::prelude::*;
 
 /// evaluates a polynomial at x=1, 2, 3, ... n (inclusive)
-pub(crate) fn encode_secret_byte<W: Write>(src: &[u8], n: u8, w: &mut W) -> io::Result<()> {
+pub(crate) fn encode_secret_byte<W: Write>(src: &[u8], k: u8, n: u8, w: &mut W) -> io::Result<()> {
     for raw_x in 1..(u16::from(n) + 1) {
         let x = Gf256::from_byte(raw_x as u8);
-        let mut fac = Gf256::one();
-        let mut acc = Gf256::zero();
-        for &coeff in src.iter() {
-            acc += fac * Gf256::from_byte(coeff);
-            fac *= x;
+        let mut acc = Gf256::from_byte(src[(k - 1) as usize]);
+        for &coeff in src[..((k - 1) as usize)].iter().rev() {
+            acc = Gf256::from_byte(coeff) + acc * x;
         }
         w.write_all(&[acc.to_byte()])?;
     }

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -79,7 +79,7 @@ impl SSS {
             col_in[0] = s;
             osrng.fill_bytes(&mut col_in[1..]);
             col_out.clear();
-            encode_secret_byte(&*col_in, shares_count, &mut col_out)?;
+            encode_secret_byte(&*col_in, threshold, shares_count, &mut col_out)?;
             for (&y, share) in col_out.iter().zip(result.iter_mut()) {
                 share[c] = y;
             }


### PR DESCRIPTION
Horner's method is an algorithm for calculating polynomials, which consists of
transforming the monomial form into a computationally efficient form. It is
pretty easy to understand:
https://en.wikipedia.org/wiki/Horner%27s_method#Description_of_the_algorithm

This implementation has resulted in a noticeable secret share generation speedup
as the RustySecrets benchmarks show, especially when calculating larger
polynomials:

Before:
test sss::generate_1kb_10_25        ... bench:   3,104,391 ns/iter (+/- 113,824)
test sss::generate_1kb_3_5          ... bench:     951,807 ns/iter (+/- 41,067)

After:
test sss::generate_1kb_10_25        ... bench:   2,657,012 ns/iter (+/- 26,998)
test sss::generate_1kb_3_5          ... bench:     885,919 ns/iter (+/- 51,110)