### PR TITLE
Small Rustfmt formatting fix to build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,8 +78,8 @@ fn main() {
     write!(
         f,
         "pub struct Tables {{ \
-             pub exp: [u8; 256], \
-             pub log: [u8; 256] \
+         pub exp: [u8; 256], \
+         pub log: [u8; 256] \
          }} \
          \
          pub static TABLES: Tables = "


### PR DESCRIPTION
This project must be using https://github.com/rust-lang-nursery/rustfmt because this PR fixes the only lines that break it standards.