### PR TITLE
Partial interpolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,50 @@
-
-sudo: required
-
 language: rust
+cache: cargo # https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
 
 rust:
   - stable
   - beta
-  - nightly
 
 matrix:
+  # Since this item is allowed to fail, don't wait for it's result to mark the
+  # build complete.
+  fast_finish: true
   allow_failures:
-    - rust: nightly
+    - env: NAME='nightly'
+    - env: NAME='kcov'
+  include:
+    - env: NAME='nightly'
+      rust: nightly
+    - env: NAME='rustfmt'
+      rust: nightly
+      before_script:
+        - rustup component add rustfmt-preview
+      script:
+        - cargo fmt --all -- --write-mode=diff
+    - env: NAME='kcov'
+      sudo: required # travis-ci/travis-ci#9061
+      before_script:
+        - cargo install cargo-update || echo "cargo-update already installed"
+        - cargo install cargo-kcov || echo "cargo-kcov already installed"
+        - cargo install-update -a
+      script:
+        - cargo kcov --print-install-kcov-sh | sh
+        - cargo update # Creates `Cargo.lock` needed by next command
+        - cargo kcov --verbose --features dss --coveralls -- --verify --exclude-pattern=/.cargo,/usr/lib,src/proto
+      addons:
+        apt:
+          packages:
+            - libcurl4-openssl-dev
+            - libdw-dev
+            - binutils-dev
+            - libiberty-dev
+            - zlib1g-dev 
 
 env:
   global:
   - RUSTFLAGS="-C link-dead-code"
 
-addons:
-  apt:
-    packages:
-      - libcurl4-openssl-dev
-      - libdw-dev
-      - cmake
-      - g++
-      - pkg-config
-      - binutils-dev
-      - libiberty-dev
-
 script:
   - cargo build --verbose --all-features
   - cargo test --verbose --all-features
-
-after_success:
-  - cargo install cargo-kcov
-  - cargo kcov --print-install-kcov-sh | sh
-  - cargo kcov --verbose --features dss --coveralls -- --verify --exclude-pattern=/.cargo,/usr/lib,src/proto
-
+  - cargo doc --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dss = []
 
 [dependencies]
 base64 = "0.9.0"
-rand = "^0.3"
+rand = "^0.4.2"
 ring = "^0.12"
 merkle_sigs = "^1.4"
 protobuf = "^1.4"
@@ -63,4 +63,3 @@ tag-prefix = "v"
 tag-message = "Release version {{version}}."
 doc-commit-message = "Update documentation."
 dev-version-ext = "pre"
-

--- a/benches/ss1.rs
+++ b/benches/ss1.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 #![feature(test)]
+#![cfg(feature = "dss")]
 
 extern crate rusty_secrets;
 extern crate test;

--- a/benches/ss1.rs
+++ b/benches/ss1.rs
@@ -10,29 +10,37 @@ mod shared;
 mod ss1 {
 
     use rusty_secrets::dss::ss1;
-    use test::{black_box, Bencher};
     use shared;
+    use test::{black_box, Bencher};
 
     macro_rules! bench_generate {
-        ($name:ident, $k:expr, $n:expr, $secret:ident) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
 
                 b.iter(move || {
-                    let shares = ss1::split_secret($k, $n, &secret, ss1::Reproducibility::reproducible(), &None).unwrap();
+                    let shares = ss1::split_secret(
+                        $k,
+                        $n,
+                        &secret,
+                        ss1::Reproducibility::reproducible(),
+                        &None,
+                    ).unwrap();
                     black_box(shares);
                 });
             }
-        )
+        };
     }
 
     macro_rules! bench_recover {
-        ($name:ident, $k:expr, $n:expr, $secret:ident) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
-                let all_shares = ss1::split_secret($k, $n, &secret, ss1::Reproducibility::reproducible(), &None).unwrap();
+                let all_shares =
+                    ss1::split_secret($k, $n, &secret, ss1::Reproducibility::reproducible(), &None)
+                        .unwrap();
                 let shares = &all_shares.into_iter().take($k).collect::<Vec<_>>().clone();
 
                 b.iter(|| {
@@ -40,7 +48,7 @@ mod ss1 {
                     black_box(result);
                 });
             }
-        )
+        };
     }
 
     bench_generate!(generate_1kb_3_5, 3, 5, secret_1kb);

--- a/benches/sss.rs
+++ b/benches/sss.rs
@@ -8,12 +8,12 @@ mod shared;
 
 mod sss {
 
-    use test::{black_box, Bencher};
     use rusty_secrets::sss;
     use shared;
+    use test::{black_box, Bencher};
 
     macro_rules! bench_generate {
-        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
@@ -23,11 +23,11 @@ mod sss {
                     black_box(shares);
                 });
             }
-        )
+        };
     }
 
     macro_rules! bench_recover {
-        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
@@ -39,7 +39,7 @@ mod sss {
                     black_box(result);
                 });
             }
-        )
+        };
     }
 
     bench_generate!(generate_1kb_3_5, 3, 5, secret_1kb, false);

--- a/benches/thss.rs
+++ b/benches/thss.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 #![feature(test)]
+#![cfg(feature = "dss")]
 
 extern crate rusty_secrets;
 extern crate test;

--- a/benches/thss.rs
+++ b/benches/thss.rs
@@ -10,11 +10,11 @@ mod shared;
 mod thss {
 
     use rusty_secrets::dss::thss;
-    use test::{black_box, Bencher};
     use shared;
+    use test::{black_box, Bencher};
 
     macro_rules! bench_generate {
-        ($name:ident, $k:expr, $n:expr, $secret:ident) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
@@ -24,11 +24,11 @@ mod thss {
                     black_box(shares);
                 });
             }
-        )
+        };
     }
 
     macro_rules! bench_recover {
-        ($name:ident, $k:expr, $n:expr, $secret:ident) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
@@ -40,7 +40,7 @@ mod thss {
                     black_box(result);
                 });
             }
-        )
+        };
     }
 
     bench_generate!(generate_1kb_3_5, 3, 5, secret_1kb);

--- a/benches/wrapped_secrets.rs
+++ b/benches/wrapped_secrets.rs
@@ -8,30 +8,32 @@ mod shared;
 
 mod wrapped_secrets {
 
-    use test::{black_box, Bencher};
     use rusty_secrets::wrapped_secrets;
     use shared;
+    use test::{black_box, Bencher};
 
     macro_rules! bench_generate {
-        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
 
                 b.iter(move || {
-                    let shares = wrapped_secrets::split_secret($k, $n, secret, None, $signed).unwrap();
+                    let shares =
+                        wrapped_secrets::split_secret($k, $n, secret, None, $signed).unwrap();
                     black_box(shares);
                 });
             }
-        )
+        };
     }
 
     macro_rules! bench_recover {
-        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => (
+        ($name:ident, $k:expr, $n:expr, $secret:ident, $signed:expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
                 let secret = shared::$secret();
-                let all_shares = wrapped_secrets::split_secret($k, $n, &secret, None, $signed).unwrap();
+                let all_shares =
+                    wrapped_secrets::split_secret($k, $n, &secret, None, $signed).unwrap();
                 let shares = all_shares.into_iter().take($k).collect::<Vec<_>>();
 
                 b.iter(|| {
@@ -39,7 +41,7 @@ mod wrapped_secrets {
                     black_box(result);
                 });
             }
-        )
+        };
     }
 
     bench_generate!(generate_1kb_3_5, 3, 5, secret_1kb, false);

--- a/build.rs
+++ b/build.rs
@@ -78,8 +78,8 @@ fn main() {
     write!(
         f,
         "pub struct Tables {{ \
-             pub exp: [u8; 256], \
-             pub log: [u8; 256] \
+         pub exp: [u8; 256], \
+         pub log: [u8; 256] \
          }} \
          \
          pub static TABLES: Tables = "

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 use std::env;
+use std::fmt;
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
-use std::fmt;
 use std::num::Wrapping;
+use std::path::Path;
 
 const POLY: u8 = 0x1D;
 

--- a/src/dss/format.rs
+++ b/src/dss/format.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
-use protobuf::{self, Message};
 use base64;
+use protobuf::{self, Message};
 
 use errors::*;
 use proto::dss::ShareProto;

--- a/src/dss/metadata.rs
+++ b/src/dss/metadata.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
 use ring::digest;
+use std::collections::BTreeMap;
 
 /// A share's public metadata.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]

--- a/src/dss/mod.rs
+++ b/src/dss/mod.rs
@@ -27,8 +27,8 @@
 //! **ErrDet**   | An inauthentic set of shares produced by an adversary will be flagged as such when fed to the recovery algorithm.
 //! **Repro**    | Share reproducible: The scheme can produce shares in a deterministic way.
 
-pub mod thss;
 pub mod ss1;
+pub mod thss;
 
 mod metadata;
 

--- a/src/dss/ss1/mod.rs
+++ b/src/dss/ss1/mod.rs
@@ -29,8 +29,8 @@ mod share;
 pub use self::share::*;
 
 mod scheme;
-use self::scheme::SS1;
 pub use self::scheme::Reproducibility;
+use self::scheme::SS1;
 
 use dss::AccessStructure;
 

--- a/src/dss/ss1/scheme.rs
+++ b/src/dss/ss1/scheme.rs
@@ -1,17 +1,17 @@
 use std::collections::HashSet;
 
-use ring::{hkdf, hmac};
-use ring::rand::{SecureRandom, SystemRandom};
-use ring::digest::{Context, SHA256};
 use rand::{ChaChaRng, Rng, SeedableRng};
+use ring::digest::{Context, SHA256};
+use ring::rand::{SecureRandom, SystemRandom};
+use ring::{hkdf, hmac};
 
-use errors::*;
-use dss::{thss, AccessStructure};
-use dss::thss::{MetaData, ThSS};
-use dss::random::{random_bytes_count, FixedRandom, MAX_MESSAGE_SIZE};
-use share::validation::{validate_share_count, validate_shares};
 use super::share::*;
+use dss::random::{random_bytes_count, FixedRandom, MAX_MESSAGE_SIZE};
+use dss::thss::{MetaData, ThSS};
 use dss::utils;
+use dss::{thss, AccessStructure};
+use errors::*;
+use share::validation::{validate_share_count, validate_shares};
 use vol_hash::VOLHash;
 
 /// We bound the message size at about 16MB to avoid overflow in `random_bytes_count`.

--- a/src/dss/ss1/scheme.rs
+++ b/src/dss/ss1/scheme.rs
@@ -248,7 +248,14 @@ impl SS1 {
         shares: &[Share],
     ) -> Result<(Vec<u8>, AccessStructure, Option<MetaData>)> {
         let shares = shares.to_vec();
-        validate_shares(&shares)?;
+        let (threshold, _) = validate_shares(&shares, None, None, None)?;
+        // TODO: rewrite validation mod, so we can nix this `if` statement.
+        if shares.len() < threshold as usize {
+            bail!(ErrorKind::MissingShares(
+                shares.len() as u8,
+                threshold
+            ))
+        }
 
         let underlying_shares = shares
             .iter()

--- a/src/dss/ss1/scheme.rs
+++ b/src/dss/ss1/scheme.rs
@@ -247,7 +247,8 @@ impl SS1 {
         &self,
         shares: &[Share],
     ) -> Result<(Vec<u8>, AccessStructure, Option<MetaData>)> {
-        let (_, shares) = validate_shares(shares.to_vec())?;
+        let shares = shares.to_vec();
+        validate_shares(&shares)?;
 
         let underlying_shares = shares
             .iter()

--- a/src/dss/ss1/scheme.rs
+++ b/src/dss/ss1/scheme.rs
@@ -254,7 +254,7 @@ impl SS1 {
             .iter()
             .map(|share| thss::Share {
                 id: share.id,
-                threshold: share.threshold,
+                threshold,
                 shares_count: share.shares_count,
                 data: share.data.clone(),
                 metadata: share.metadata.clone(),

--- a/src/dss/ss1/scheme.rs
+++ b/src/dss/ss1/scheme.rs
@@ -11,7 +11,7 @@ use dss::thss::{MetaData, ThSS};
 use dss::utils;
 use dss::{thss, AccessStructure};
 use errors::*;
-use share::validation::{validate_share_count, validate_shares};
+use share::validation::{validate_all_shares, validate_share_count};
 use vol_hash::VOLHash;
 
 /// We bound the message size at about 16MB to avoid overflow in `random_bytes_count`.
@@ -248,14 +248,7 @@ impl SS1 {
         shares: &[Share],
     ) -> Result<(Vec<u8>, AccessStructure, Option<MetaData>)> {
         let shares = shares.to_vec();
-        let (threshold, _) = validate_shares(&shares, None, None, None)?;
-        // TODO: rewrite validation mod, so we can nix this `if` statement.
-        if shares.len() < threshold as usize {
-            bail!(ErrorKind::MissingShares(
-                shares.len() as u8,
-                threshold
-            ))
-        }
+        let (threshold, _) = validate_all_shares(&shares)?;
 
         let underlying_shares = shares
             .iter()

--- a/src/dss/ss1/serialize.rs
+++ b/src/dss/ss1/serialize.rs
@@ -1,8 +1,8 @@
-use errors::*;
 use super::{MetaData, Share};
 use dss::format::{format_share_protobuf, parse_share_protobuf};
-use proto::dss::{MetaDataProto, ShareProto};
 use dss::utils::{btreemap_to_hashmap, hashmap_to_btreemap};
+use errors::*;
+use proto::dss::{MetaDataProto, ShareProto};
 
 pub(crate) fn share_to_string(share: Share) -> String {
     let proto = share_to_protobuf(share);

--- a/src/dss/ss1/share.rs
+++ b/src/dss/ss1/share.rs
@@ -1,6 +1,6 @@
+use super::serialize::{share_from_string, share_to_string};
 use errors::*;
 use share::IsShare;
-use super::serialize::{share_from_string, share_to_string};
 
 pub use dss::metadata::MetaData;
 

--- a/src/dss/thss/scheme.rs
+++ b/src/dss/thss/scheme.rs
@@ -90,7 +90,14 @@ impl ThSS {
         shares: &[Share],
     ) -> Result<(Vec<u8>, AccessStructure, Option<MetaData>)> {
         let shares = shares.to_vec();
-        let (threshold, cypher_len) = validate_shares(&shares)?;
+        let (threshold, cypher_len) = validate_shares(&shares, None, None, None)?;
+        // TODO: rewrite validation mod, so we can nix this `if` statement.
+        if shares.len() < threshold as usize {
+            bail!(ErrorKind::MissingShares(
+                shares.len() as u8,
+                threshold
+            ))
+        }
 
         let polys = (0..cypher_len)
             .map(|i| {

--- a/src/dss/thss/scheme.rs
+++ b/src/dss/thss/scheme.rs
@@ -4,15 +4,15 @@ use std::fmt;
 
 use ring::rand::{SecureRandom, SystemRandom};
 
+use dss::random::{random_bytes, random_bytes_count, MAX_MESSAGE_SIZE};
 use errors::*;
 use gf256::Gf256;
-use dss::random::{random_bytes, random_bytes_count, MAX_MESSAGE_SIZE};
-use share::validation::{validate_share_count, validate_shares};
 use lagrange;
+use share::validation::{validate_share_count, validate_shares};
 
 use super::AccessStructure;
-use super::share::*;
 use super::encode::encode_secret;
+use super::share::*;
 
 /// We bound the message size at about 16MB to avoid overflow in `random_bytes_count`.
 /// Moreover, given the current performances, it is almost unpractical to run

--- a/src/dss/thss/scheme.rs
+++ b/src/dss/thss/scheme.rs
@@ -8,7 +8,7 @@ use dss::random::{random_bytes, random_bytes_count, MAX_MESSAGE_SIZE};
 use errors::*;
 use gf256::Gf256;
 use lagrange;
-use share::validation::{validate_share_count, validate_shares};
+use share::validation::{validate_all_shares, validate_share_count};
 
 use super::AccessStructure;
 use super::encode::encode_secret;
@@ -90,14 +90,7 @@ impl ThSS {
         shares: &[Share],
     ) -> Result<(Vec<u8>, AccessStructure, Option<MetaData>)> {
         let shares = shares.to_vec();
-        let (threshold, cypher_len) = validate_shares(&shares, None, None, None)?;
-        // TODO: rewrite validation mod, so we can nix this `if` statement.
-        if shares.len() < threshold as usize {
-            bail!(ErrorKind::MissingShares(
-                shares.len() as u8,
-                threshold
-            ))
-        }
+        let (threshold, cypher_len) = validate_all_shares(&shares)?;
 
         let polys = (0..cypher_len)
             .map(|i| {

--- a/src/dss/thss/scheme.rs
+++ b/src/dss/thss/scheme.rs
@@ -89,9 +89,8 @@ impl ThSS {
         &self,
         shares: &[Share],
     ) -> Result<(Vec<u8>, AccessStructure, Option<MetaData>)> {
-        let (threshold, shares) = validate_shares(shares.to_vec())?;
-
-        let cypher_len = shares[0].data.len();
+        let shares = shares.to_vec();
+        let (threshold, cypher_len) = validate_shares(&shares)?;
 
         let polys = (0..cypher_len)
             .map(|i| {

--- a/src/dss/thss/serialize.rs
+++ b/src/dss/thss/serialize.rs
@@ -1,8 +1,8 @@
-use errors::*;
 use super::{MetaData, Share};
 use dss::format::{format_share_protobuf, parse_share_protobuf};
-use proto::dss::{MetaDataProto, ShareProto};
 use dss::utils::{btreemap_to_hashmap, hashmap_to_btreemap};
+use errors::*;
+use proto::dss::{MetaDataProto, ShareProto};
 
 pub(crate) fn share_to_string(share: Share) -> String {
     let proto = share_to_protobuf(share);

--- a/src/dss/thss/share.rs
+++ b/src/dss/thss/share.rs
@@ -1,6 +1,6 @@
+use super::serialize::{share_from_string, share_to_string};
 use errors::*;
 use share::IsShare;
-use super::serialize::{share_from_string, share_to_string};
 
 pub use dss::metadata::MetaData;
 

--- a/src/dss/utils.rs
+++ b/src/dss/utils.rs
@@ -1,7 +1,7 @@
 use std;
 
-use std::hash::Hash;
 use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
 
 /// Transmutes a `&[u8]` into a `&[u32]`.
 /// Despite `std::mem::transmute` being very unsafe in

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -135,6 +135,11 @@ error_chain! {
             display("The share identifier {} had secret length {}, while the secret length {} was found for share identifier(s): {}.", id, slen_, slen, no_more_than_five(ids))
         }
 
+        InconsistentSignatures(id: u8, ids: Vec<u8>) {
+            description("The shares are incompatible with each other because they have valid signatures from different keys.")
+            display("The share identifier {} was signed by a different key than share identifier(s): {}.", id, no_more_than_five(ids))
+        }
+
         InconsistentShares {
             description("The shares are inconsistent")
             display("The shares are inconsistent")
@@ -145,6 +150,10 @@ error_chain! {
             display("The share identifier {} had k = {}, while k = {} was found for share identifier(s): {}.", id, k_, k, no_more_than_five(ids))
         }
 
+        PartialInterpolationNotComplete(k: u8, shares_interpolated: u8) {
+            description("The partial interpolation result is not complete because the number of points interpolated has not reached the threshold.")
+            display("In order to evaluate the secret polynomial at any point k = {} shares are needed, whereas only {} have been provided.", k, shares_interpolated)
+        }
     }
 
     foreign_links {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,7 +59,7 @@ error_chain! {
             display("The shares are incompatible with each other.")
         }
 
-        MissingShares(provided: usize, required: usize) {
+        MissingShares(provided: usize, required: u8) {
             description("The number of shares provided is insufficient to recover the secret.")
             display("{} shares are required to recover the secret, found only {}.", required, provided)
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -92,6 +92,11 @@ error_chain! {
             display("Found invalid share identifier ({})", share_id)
         }
 
+        ShareParsingInvalidShareThreshold(k: u8, id: u8) {
+            description("Threshold k must be bigger than or equal to 2")
+            display("Threshold k must be bigger than or equal to 2. Got k = {} for share identifier {}.", k, id)
+        }
+
         InvalidSS1Parameters(r: usize, s: usize) {
             description("Invalid parameters for the SS1 sharing scheme")
             display("Invalid parameters for the SS1 sharing scheme: r = {}, s = {}.", r, s)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,6 +65,12 @@ error_chain! {
             display("{} shares are required to recover the secret, found only {}.", required, provided)
         }
 
+        NoMoreSharesNeeded(required: u8) {
+            description("The number of shares evaluated has already met the threshold and the
+            secret is available.")
+            display("Only {} shares are required to recover the secret.", required)
+        }
+
         InvalidSignature(share_id: u8, signature: String) {
             description("The signature of this share is not valid.")
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -164,7 +164,7 @@ error_chain! {
 
 /// Takes a `Vec<T>` and formats it like the normal `fmt::Debug` implementation, unless it has more
 //than five elements, in which case the rest are replaced by ellipsis.
-fn no_more_than_five<T: fmt::Debug + fmt::Display>(vec: &Vec<T>) -> String {
+fn no_more_than_five<T: fmt::Debug + fmt::Display>(vec: &[T]) -> String {
     let len = vec.len();
     if len > 5 {
         let mut string = String::from("[");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -118,11 +118,6 @@ error_chain! {
             display("This share number ({}) has already been used by a previous share.", share_id)
         }
 
-        DuplicateShareData(share_id: u8) {
-            description("The data encoded in this share is the same as the one found in a previous share")
-            display("The data encoded in share #{} is the same as the one found in a previous share.", share_id)
-        }
-
         InconsistentShares {
             description("The shares are inconsistent")
             display("The shares are inconsistent")

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,6 +59,11 @@ error_chain! {
             display("The shares are incompatible with each other.")
         }
 
+        IncompatibleThresholds(sets: Vec<HashSet<u8>>) {
+            description("The shares are incompatible with each other because they do not all have the same threshold.")
+            display("The shares are incompatible with each other because they do not all have the same threshold.")
+        }
+
         MissingShares(provided: usize, required: u8) {
             description("The number of shares provided is insufficient to recover the secret.")
             display("{} shares are required to recover the secret, found only {}.", required, provided)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,16 +59,6 @@ error_chain! {
             display("The shares are incompatible with each other.")
         }
 
-        IncompatibleThresholds(sets: Vec<HashSet<u8>>) {
-            description("The shares are incompatible with each other because they do not all have the same threshold.")
-            display("The shares are incompatible with each other because they do not all have the same threshold.")
-        }
-
-        IncompatibleDataLengths(sets: Vec<HashSet<u8>>) {
-            description("The shares are incompatible with each other because they do not all have the same share data length.")
-            display("The shares are incompatible with each other because they do not all have the same share data length.")
-        }
-
         MissingShares(provided: usize, required: u8) {
             description("The number of shares provided is insufficient to recover the secret.")
             display("{} shares are required to recover the secret, found only {}.", required, provided)
@@ -133,10 +123,21 @@ error_chain! {
             display("This share number ({}) has already been used by a previous share.", share_id)
         }
 
+        InconsistentSecretLengths(id: u8, slen_: usize, ids: Vec<u8>, slen: usize) {
+            description("The shares are incompatible with each other because they do not all have the same secret length.")
+            display("The share identifier {} had secret length {}, while the secret length {} was found for share identifier(s): {:?}.", id, slen_, slen, ids)
+        }
+
         InconsistentShares {
             description("The shares are inconsistent")
             display("The shares are inconsistent")
         }
+
+        InconsistentThresholds(id: u8, k_: u8, ids: Vec<u8>, k: u8) {
+            description("The shares are incompatible with each other because they do not all have the same threshold.")
+            display("The share identifier {} had k = {}, while k = {} was found for share identifier(s): {:?}.", id, k_, k, ids)
+        }
+
     }
 
     foreign_links {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -64,6 +64,11 @@ error_chain! {
             display("The shares are incompatible with each other because they do not all have the same threshold.")
         }
 
+        IncompatibleDataLengths(sets: Vec<HashSet<u8>>) {
+            description("The shares are incompatible with each other because they do not all have the same share data length.")
+            display("The shares are incompatible with each other because they do not all have the same share data length.")
+        }
+
         MissingShares(provided: usize, required: u8) {
             description("The number of shares provided is insufficient to recover the secret.")
             display("{} shares are required to recover the secret, found only {}.", required, provided)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,11 +59,6 @@ error_chain! {
             display("The shares are incompatible with each other.")
         }
 
-        ShareIdentifierTooBig(id: u8, n: u8) {
-            description("Share identifier too big")
-            display("Found share identifier ({}) bigger than the maximum number of shares ({}).", id, n)
-        }
-
         MissingShares(provided: usize, required: usize) {
             description("The number of shares provided is insufficient to recover the secret.")
             display("{} shares are required to recover the secret, found only {}.", required, provided)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,7 +60,7 @@ error_chain! {
             display("The shares are incompatible with each other.")
         }
 
-        MissingShares(provided: usize, required: u8) {
+        MissingShares(provided: u8, required: u8) {
             description("The number of shares provided is insufficient to recover the secret.")
             display("{} shares are required to recover the secret, found only {}.", required, provided)
         }
@@ -150,10 +150,10 @@ error_chain! {
             display("The share identifier {} had k = {}, while k = {} was found for share identifier(s): {}.", id, k_, k, no_more_than_five(ids))
         }
 
-        PartialInterpolationNotComplete(k: u8, shares_interpolated: u8) {
-            description("The partial interpolation result is not complete because the number of points interpolated has not reached the threshold.")
-            display("In order to evaluate the secret polynomial at any point k = {} shares are needed, whereas only {} have been provided.", k, shares_interpolated)
-        }
+        // PartialInterpolationNotComplete(k: u8, shares_interpolated: u8) {
+        //     description("The partial interpolation result is not complete because the number of points interpolated has not reached the threshold.")
+        //     display("In order to evaluate the secret polynomial at any point k = {} shares are needed, whereas only {} have been provided.", k, shares_interpolated)
+        // }
     }
 
     foreign_links {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,7 +68,7 @@ error_chain! {
         NoMoreSharesNeeded(required: u8) {
             description("The number of shares evaluated has already met the threshold and the
             secret is available.")
-            display("Only {} shares are required to recover the secret.", required)
+            display("Only {} shares are required to recover the secret. The secret should already be available.", required)
         }
 
         InvalidSignature(share_id: u8, signature: String) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@
 #![allow(unknown_lints, missing_docs)]
 
 use std::collections::HashSet;
+use std::fmt;
 
 #[cfg(feature = "dss")]
 use dss::ss1;
@@ -125,7 +126,7 @@ error_chain! {
 
         InconsistentSecretLengths(id: u8, slen_: usize, ids: Vec<u8>, slen: usize) {
             description("The shares are incompatible with each other because they do not all have the same secret length.")
-            display("The share identifier {} had secret length {}, while the secret length {} was found for share identifier(s): {:?}.", id, slen_, slen, ids)
+            display("The share identifier {} had secret length {}, while the secret length {} was found for share identifier(s): {}.", id, slen_, slen, no_more_than_five(ids))
         }
 
         InconsistentShares {
@@ -135,7 +136,7 @@ error_chain! {
 
         InconsistentThresholds(id: u8, k_: u8, ids: Vec<u8>, k: u8) {
             description("The shares are incompatible with each other because they do not all have the same threshold.")
-            display("The share identifier {} had k = {}, while k = {} was found for share identifier(s): {:?}.", id, k_, k, ids)
+            display("The share identifier {} had k = {}, while k = {} was found for share identifier(s): {}.", id, k_, k, no_more_than_five(ids))
         }
 
     }
@@ -143,5 +144,21 @@ error_chain! {
     foreign_links {
         Io(::std::io::Error);
         IntegerParsingError(::std::num::ParseIntError);
+    }
+}
+
+/// Takes a `Vec<T>` and formats it like the normal `fmt::Debug` implementation, unless it has more
+//than five elements, in which case the rest are replaced by ellipsis.
+fn no_more_than_five<T: fmt::Debug + fmt::Display>(vec: &Vec<T>) -> String {
+    let len = vec.len();
+    if len > 5 {
+        let mut string = String::from("[");
+        for item in vec.iter().take(5) {
+            string += &format!("{}, ", item);
+        }
+        string.push_str("...]");
+        string
+    } else {
+        format!("{:?}", vec)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -149,11 +149,6 @@ error_chain! {
             description("The shares are incompatible with each other because they do not all have the same threshold.")
             display("The share identifier {} had k = {}, while k = {} was found for share identifier(s): {}.", id, k_, k, no_more_than_five(ids))
         }
-
-        // PartialInterpolationNotComplete(k: u8, shares_interpolated: u8) {
-        //     description("The partial interpolation result is not complete because the number of points interpolated has not reached the threshold.")
-        //     display("In order to evaluate the secret polynomial at any point k = {} shares are needed, whereas only {} have been provided.", k, shares_interpolated)
-        // }
     }
 
     foreign_links {

--- a/src/gf256.rs
+++ b/src/gf256.rs
@@ -66,6 +66,7 @@ impl Gf256 {
     }
 }
 
+#[allow(suspicious_arithmetic_impl)]
 impl Add<Gf256> for Gf256 {
     type Output = Gf256;
     #[inline]
@@ -81,6 +82,7 @@ impl AddAssign<Gf256> for Gf256 {
     }
 }
 
+#[allow(suspicious_arithmetic_impl)]
 impl Sub<Gf256> for Gf256 {
     type Output = Gf256;
     #[inline]

--- a/src/gf256.rs
+++ b/src/gf256.rs
@@ -143,7 +143,9 @@ impl Neg for Gf256 {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! gf256 {
-    ($e:expr) => (Gf256::from_byte($e))
+    ($e:expr) => {
+        Gf256::from_byte($e)
+    };
 }
 
 #[macro_export]
@@ -178,10 +180,10 @@ mod tests {
 
     mod vectors {
         use super::*;
+        use flate2::read::GzDecoder;
+        use itertools::Itertools;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
-        use itertools::Itertools;
-        use flate2::read::GzDecoder;
 
         macro_rules! mk_test {
             ($id:ident, $op:expr, $val:expr) => {
@@ -196,7 +198,8 @@ mod tests {
                     });
 
                     let ref_path = format!("tests/fixtures/gf256/gf256_{}.txt.gz", stringify!($id));
-                    let reference = BufReader::new(GzDecoder::new(File::open(ref_path).unwrap()).unwrap());
+                    let reference =
+                        BufReader::new(GzDecoder::new(File::open(ref_path).unwrap()).unwrap());
 
                     for ((i, j, k), line) in results.zip(reference.lines()) {
                         let left = format!("{} {} {} = {}", i, $op, j, k);
@@ -204,7 +207,7 @@ mod tests {
                         assert_eq!(left, right);
                     }
                 }
-            }
+            };
         }
 
         mk_test!(add, "+", |i: Gf256, j: Gf256| i + j);

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -94,7 +94,7 @@ impl PartialSecret {
             return;
         }
 
-        let x = if self.weights.len() == 0 {
+        let x = if self.weights.is_empty() {
             // Initialize initial weights.
             self.weights = vec![Gf256::zero(); self.ids.len()];
             self.weights[0] = Gf256::one();

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -1,59 +1,167 @@
+use std::u8;
+
+use errors::*;
 use gf256::Gf256;
 use poly::Poly;
 
 /// Evaluates an interpolated polynomial at `Gf256::zero()` where the polynomial is determined
 /// using barycentric Lagrange interpolation based on the given `points` in the G(2^8) Galois
 /// field.
-pub(crate) fn interpolate_at(points: &[(u8, u8)]) -> u8 {
-    // Algorithm from "Polynomial Interpolation: Langrange vs Newton" by Wilhelm Werner.
-    let x = points.iter().map(|x| Gf256::from_byte(x.0)).collect();
-    let y = points.iter().map(|x| Gf256::from_byte(x.1)).collect();
-    let w = compute_barycentric_weights(&x);
-    let (num, denom) = compute_barycentric_num_denom_at(&x, &y, &w);
-    (num / denom).to_byte()
+pub(crate) fn interpolate_at(threshold: u8, points: &[(u8, u8)]) -> Result<u8> {
+    if points.len() < threshold as usize {
+        bail!(ErrorKind::MissingShares(points.len(), threshold as usize));
+    }
+    let partial_comp = PartialSecret::new(threshold, points)?;
+    Ok(partial_comp.secret.unwrap())
 }
 
-/// Compute the barycentric weights `w` corresponding to a set of `x` values.
-#[inline]
-fn compute_barycentric_weights(x: &Vec<Gf256>) -> Vec<Gf256> {
-    let k = x.len();
-    let mut w = vec![Gf256::zero(); k];
-    w[0] = Gf256::one();
+/// Stores the intermediate state of interpolation and evaluation at `Gf256::zero()` of a
+/// polynomial. A secret may be computed incrementally using barycentric Lagrange interpolation.
+/// The state is updated with new points until threshold points have been evaluated, at which point
+/// the `secret` field will be updated from `None` to `Some(u8)`.
+pub struct PartialSecret {
+    /// The secret byte. `None` until computation is complete.
+    secret: Option<u8>,
+    /// The number of shares necessary to recover the secret, a.k.a. the threshold.
+    threshold: u8,
+    /// The ids of the share (varies between 1 and n where n is the total number of generated
+    /// shares)
+    ids: Vec<Gf256>,
+    /// The differences of share values divided by their ids.
+    differences: Vec<Gf256>,
+    /// The barycentric weights.
+    weights: Vec<Gf256>,
+}
 
-    for i in 1..k {
-        for j in 0..i {
-            let delta = x[j] - x[i];
-            assert_ne!(delta.poly, 0, "Duplicate shares");
-            w[j] /= delta;
-            w[i] -= w[j];
+impl PartialSecret {
+    /// Create a new partial computation given a `threshold` (to know when the computation is
+    /// finished), and an initial set of `points`.
+    #[inline]
+    pub fn new(threshold: u8, points: &[(u8, u8)]) -> Result<Self> {
+        if threshold < 2 {
+            bail!(ErrorKind::ThresholdTooSmall(threshold));
+        } else if points.len() == 0 {
+            bail!(ErrorKind::EmptyShares);
+        } else if points.len() > MAX_SHARES as usize {
+            bail!(ErrorKind::InvalidShareCountMax(
+                points.len() as u8,
+                MAX_SHARES
+            ));
+        }
+
+        let mut ids = Vec::with_capacity(points.len());
+        let mut differences = Vec::with_capacity(points.len());
+        // If provided with more than `threshold` points, only the first threshold are considered.
+        for pi in points.iter().take(threshold as usize) {
+            if pi.0 == 0 {
+                bail!(ErrorKind::ShareParsingInvalidShareId(0));
+            }
+            let xi = Gf256::from_byte(pi.0);
+            if ids.iter().find(|&&xj| xi == xj).is_some() {
+                bail!(ErrorKind::DuplicateShareId(xi.poly));
+            }
+            let yi = Gf256::from_byte(pi.1);
+            ids.push(xi);
+            differences.push(yi / xi);
+        }
+
+        let mut partial_comp = Self {
+            secret: None,
+            threshold,
+            ids,
+            differences,
+            weights: vec![],
+        };
+
+        if partial_comp.ids.len() == 1 {
+            return Ok(partial_comp);
+        }
+
+        partial_comp.update_barycentric_weights();
+        Ok(partial_comp)
+    }
+
+    #[inline]
+    pub fn update(&mut self, points: &[(u8, u8)]) -> Result<()> {
+        if points.len() == 0 {
+            bail!(ErrorKind::EmptyShares);
+        } else if points.len() + self.ids.len() > MAX_SHARES as usize {
+            bail!(ErrorKind::InvalidShareCountMax(
+                (points.len() + self.ids.len()) as u8,
+                MAX_SHARES
+            ));
+        }
+
+        // If provided with more than than `threshold - self.ids.len()` points, only enough to
+        // satisfy the threshold are considered.
+        for pi in points.iter().take(self.threshold as usize - self.ids.len()) {
+            if pi.0 == 0 {
+                bail!(ErrorKind::ShareParsingInvalidShareId(0));
+            }
+            let xi = Gf256::from_byte(pi.0);
+            if self.ids.iter().find(|&&xj| xi == xj).is_some() {
+                bail!(ErrorKind::DuplicateShareId(xi.poly));
+            }
+            let yi = Gf256::from_byte(pi.1);
+            self.ids.push(xi);
+            self.differences.push(yi / xi);
+        }
+
+        self.update_barycentric_weights();
+        Ok(())
+    }
+
+    /// Update the barycentric weights `w` corresponding to a set of `x` values.
+    #[inline]
+    fn update_barycentric_weights(&mut self) {
+        let x = if self.weights.len() == 0 {
+            // Initialize initial weights.
+            self.weights = vec![Gf256::zero(); self.ids.len()];
+            self.weights[0] = Gf256::one();
+            1
+        } else {
+            // Initialize additional weights.
+            let initial_len = self.weights.len();
+            self.weights
+                .append(&mut vec![Gf256::zero(); self.ids.len() - initial_len]);
+            initial_len
+        };
+
+        // Update weights using algorithm (3.1) from "Polynomial Interpolation: Langrange vs
+        // Newton" by Wilhelm Werner.
+        for i in x..self.ids.len() {
+            for j in 0..i {
+                self.weights[j] /= self.ids[j] - self.ids[i];
+                self.weights[i] -= self.weights[j];
+            }
+        }
+
+        // If we have sufficient information, we can compute the secret.
+        if self.weights.len() == self.threshold as usize {
+            self.compute_secret();
         }
     }
 
-    w
-}
-
-// Compute the numerator and denominator of the second or "true" form of the barycentric
-// interpolation formula at `Gf256::zero()`.
-#[inline]
-fn compute_barycentric_num_denom_at(
-    x: &Vec<Gf256>,
-    y: &Vec<Gf256>,
-    w: &Vec<Gf256>,
-) -> (Gf256, Gf256) {
-    let (mut num, mut denom) = (Gf256::zero(), Gf256::zero());
-
-    for (i, &xi) in x.iter().enumerate() {
-        assert_ne!(xi.poly, 0, "Invalid share x = 0");
-        let diff = w[i] / xi;
-        num += diff * y[i];
-        denom += diff;
+    // Compute the secret using the second or "true" form of the barycentric interpolation formula
+    // at `Gf256::zero()`.
+    #[inline]
+    fn compute_secret(&mut self) {
+        let (mut num, mut denom) = (Gf256::zero(), Gf256::zero());
+        for ((&xi, &di), &wi) in self.ids
+            .iter()
+            .zip(self.differences.iter())
+            .zip(self.weights.iter())
+        {
+            num += wi * di;
+            denom += wi / xi;
+        }
+        self.secret = Some((num / denom).to_byte());
     }
-
-    (num, denom)
 }
 
 /// Computeds the coefficient of the Lagrange polynomial interpolated
 /// from the given `points`, in the G(2^8) Galois field.
+#[inline]
 pub(crate) fn interpolate(points: &[(Gf256, Gf256)]) -> Poly {
     let len = points.len();
 
@@ -102,12 +210,12 @@ mod tests {
     quickcheck! {
 
         fn interpolate_evaluate_at_works(ys: Vec<Gf256>) -> TestResult {
-            if ys.is_empty() || ys.len() > std::u8::MAX as usize {
+            if ys.len() < 2 || ys.len() > u8::MAX as usize {
                 return TestResult::discard();
             }
 
             let points = ys.into_iter()
-                           .zip(1..std::u8::MAX)
+                           .zip(1..u8::MAX)
                            .map(|(y, x)| (gf256!(x), y))
                            .collect::<Vec<_>>();
             let poly = interpolate(&points);
@@ -122,12 +230,12 @@ mod tests {
         }
 
         fn interpolate_evaluate_at_0_eq_evaluate_at(ys: Vec<u8>) -> TestResult {
-            if ys.is_empty() || ys.len() > std::u8::MAX as usize {
+            if ys.len() < 2 || ys.len() > u8::MAX as usize {
                 return TestResult::discard();
             }
 
             let points = ys.into_iter()
-                           .zip(1..std::u8::MAX)
+                           .zip(1..u8::MAX)
                            .map(|(y, x)| (x, y))
                            .collect::<Vec<_>>();
 
@@ -139,7 +247,7 @@ mod tests {
             let poly = interpolate(&elems);
 
             let equals = poly.evaluate_at(Gf256::zero()).to_byte()
-                == interpolate_at(points.as_slice());
+                == interpolate_at(points.len() as u8, points.as_slice()).unwrap();
 
             TestResult::from_bool(equals)
         }

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -86,10 +86,10 @@ pub(crate) fn interpolate(points: &[(Gf256, Gf256)]) -> Poly {
 #[allow(trivial_casts)]
 mod tests {
 
-    use std;
     use super::*;
     use gf256::*;
     use quickcheck::*;
+    use std;
 
     quickcheck! {
 

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -114,7 +114,7 @@ mod tests {
         }
 
         fn interpolate_evaluate_at_0_eq_evaluate_at(ys: Vec<u8>) -> TestResult {
-            if ys.len() > std::u8::MAX as usize {
+            if ys.is_empty() || ys.len() > std::u8::MAX as usize {
                 return TestResult::discard();
             }
 

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -1,12 +1,28 @@
 use gf256::Gf256;
 use poly::Poly;
 
+// Minimum number of points where it becomes faster to use barycentric
+// Lagrange interpolation. Determined by benchmarking.
+const BARYCENTRIC_THRESHOLD: u8 = 5;
+
 /// Evaluates an interpolated polynomial at `Gf256::zero()` where
-/// the polynomial is determined using Lagrangian interpolation
-/// based on the given `points` in the G(2^8) Galois field.
-pub(crate) fn interpolate_at(points: &[(u8, u8)]) -> u8 {
+/// the polynomial is determined using either standard or barycentric
+/// Lagrange interpolation (depending on number of points, `k`) based
+/// on the given `points` in the G(2^8) Galois field.
+pub(crate) fn interpolate_at(k: u8, points: &[(u8, u8)]) -> u8 {
+    if k < BARYCENTRIC_THRESHOLD {
+        lagrange_interpolate_at(points)
+    } else {
+        barycentric_interpolate_at(k as usize, points)
+    }
+}
+
+/// Evaluates the polynomial at `Gf256::zero()` using standard Langrange
+/// interpolation.
+fn lagrange_interpolate_at(points: &[(u8, u8)]) -> u8 {
     let mut sum = Gf256::zero();
     for (i, &(raw_xi, raw_yi)) in points.iter().enumerate() {
+        assert_ne!(raw_xi, 0, "Invalid share x = 0");
         let xi = Gf256::from_byte(raw_xi);
         let yi = Gf256::from_byte(raw_yi);
         let mut prod = Gf256::one();
@@ -23,6 +39,36 @@ pub(crate) fn interpolate_at(points: &[(u8, u8)]) -> u8 {
     sum.to_byte()
 }
 
+/// Barycentric Lagrange interpolation algorithm from "Polynomial
+/// Interpolation: Langrange vs Newton" by Wilhelm Werner. Evaluates
+/// the polynomial at `Gf256::zero()`.
+fn barycentric_interpolate_at(k: usize, points: &[(u8, u8)]) -> u8 {
+    // Compute the barycentric weights `w`.
+    let mut w = vec![Gf256::zero(); k];
+    w[0] = Gf256::one();
+    let mut x = Vec::with_capacity(k);
+    x.push(Gf256::from_byte(points[0].0));
+    for i in 1..k {
+        x.push(Gf256::from_byte(points[i].0));
+        for j in 0..i {
+            let delta = x[j] - x[i];
+            assert_ne!(delta.poly, 0, "Duplicate shares");
+            w[j] /= delta;
+            w[i] -= w[j];
+        }
+    }
+    // Evaluate the second or "true" form of the barycentric
+    // interpolation formula at `Gf256::zero()`.
+    let (mut num, mut denom) = (Gf256::zero(), Gf256::zero());
+    for i in 0..k {
+        assert_ne!(x[i].poly, 0, "Invalid share x = 0");
+        let diff = w[i] / x[i];
+        num += diff * Gf256::from_byte(points[i].1);
+        denom += diff;
+    }
+    (num / denom).to_byte()
+}
+
 /// Computeds the coefficient of the Lagrange polynomial interpolated
 /// from the given `points`, in the G(2^8) Galois field.
 pub(crate) fn interpolate(points: &[(Gf256, Gf256)]) -> Poly {
@@ -31,6 +77,7 @@ pub(crate) fn interpolate(points: &[(Gf256, Gf256)]) -> Poly {
     let mut poly = vec![Gf256::zero(); len];
 
     for &(x, y) in points {
+        assert_ne!(x.poly, 0, "Invalid share x = 0");
         let mut coeffs = vec![Gf256::zero(); len];
         coeffs[0] = y;
 
@@ -71,24 +118,15 @@ mod tests {
 
     quickcheck! {
 
-        fn evaluate_at_works(ys: Vec<u8>) -> TestResult {
-            if ys.is_empty() || ys.len() > std::u8::MAX as usize {
-                return TestResult::discard();
-            }
-
-            let points = ys.iter().enumerate().map(|(x, y)| (x as u8, *y)).collect::<Vec<_>>();
-            let equals = interpolate_at(points.as_slice()) == ys[0];
-
-            TestResult::from_bool(equals)
-        }
-
-
         fn interpolate_evaluate_at_works(ys: Vec<Gf256>) -> TestResult {
             if ys.is_empty() || ys.len() > std::u8::MAX as usize {
                 return TestResult::discard();
             }
 
-            let points = ys.into_iter().enumerate().map(|(x, y)| (gf256!(x as u8), y)).collect::<Vec<_>>();
+            let points = ys.into_iter()
+                           .zip(1..std::u8::MAX)
+                           .map(|(y, x)| (gf256!(x), y))
+                           .collect::<Vec<_>>();
             let poly = interpolate(&points);
 
             for (x, y) in points {
@@ -105,7 +143,10 @@ mod tests {
                 return TestResult::discard();
             }
 
-            let points = ys.into_iter().enumerate().map(|(x, y)| (x as u8, y)).collect::<Vec<_>>();
+            let points = ys.into_iter()
+                           .zip(1..std::u8::MAX)
+                           .map(|(y, x)| (x, y))
+                           .collect::<Vec<_>>();
 
             let elems = points
                 .iter()
@@ -114,7 +155,8 @@ mod tests {
 
             let poly = interpolate(&elems);
 
-            let equals = poly.evaluate_at(Gf256::zero()).to_byte() == interpolate_at(points.as_slice());
+            let equals = poly.evaluate_at(Gf256::zero()).to_byte()
+                == interpolate_at(points.len() as u8, points.as_slice());
 
             TestResult::from_bool(equals)
         }

--- a/src/lagrange.rs
+++ b/src/lagrange.rs
@@ -136,19 +136,13 @@ impl PartialSecret {
     #[inline]
     pub fn get_secret(&self) -> Result<u8> {
         if self.secret.is_none() {
-            bail!(ErrorKind::PartialInterpolationNotComplete(
-                self.threshold,
-                self.shares_interpolated()
+            bail!(ErrorKind::MissingShares(
+                self.shares_interpolated(),
+                self.threshold
             ))
         }
         // Safe to unwrap because we just confirmed it's not `None`.
         Ok(self.secret.unwrap())
-    }
-
-    /// Returns the threshold for the partial computation.
-    #[inline]
-    fn get_threshold(&self) -> u8 {
-        self.threshold
     }
 
     /// Returns the number of shares needed to complete the computation.
@@ -172,9 +166,9 @@ impl PartialSecret {
     #[inline]
     fn evaluate_at_x(&self, x: u8) -> Result<u8> {
         if self.shares_needed() != 0 {
-            bail!(ErrorKind::PartialInterpolationNotComplete(
-                self.threshold,
-                self.shares_interpolated()
+            bail!(ErrorKind::MissingShares(
+                self.shares_interpolated(),
+                self.threshold
             ))
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,15 @@ extern crate ring;
 
 #[macro_use]
 mod gf256;
-mod share;
-mod poly;
 mod lagrange;
+mod poly;
+mod share;
 mod vol_hash;
 
 pub mod errors;
+pub mod proto;
 pub mod sss;
 pub mod wrapped_secrets;
-pub mod proto;
 
 #[cfg(feature = "dss")]
 pub mod dss;

--- a/src/share/mod.rs
+++ b/src/share/mod.rs
@@ -34,7 +34,16 @@ pub(crate) trait IsSignedShare: IsShare {
     /// Return the signature itself.
     fn get_signature(&self) -> &Self::Signature;
 
-    /// Verify the signatures of the given batch of shares.
-    /// Returns `Ok(())` if validation succeeds, and an `Err` otherwise.
-    fn verify_signatures(shares: &[Self]) -> Result<()>;
+    /// Verify a given batch of shares are all signed by the same root hash. Returns the root hash
+    /// if verification succeeds, and an `Err` otherwise.
+    fn verify_signatures(shares: &[Self]) -> Result<Vec<u8>>;
+
+    /// Verify the `shares` all have valid signatures from the `root_hash`. Pass a list of shares
+    /// identifiers already verified against this `root_hash`, if any, for better error messaging
+    /// if verification fails.
+    fn continue_verify_signatures(
+        shares: &[Self],
+        root_hash: &Vec<u8>,
+        already_verified_ids: &Vec<u8>,
+    ) -> Result<()>;
 }

--- a/src/share/mod.rs
+++ b/src/share/mod.rs
@@ -43,7 +43,7 @@ pub(crate) trait IsSignedShare: IsShare {
     /// if verification fails.
     fn continue_verify_signatures(
         shares: &[Self],
-        root_hash: &Vec<u8>,
-        already_verified_ids: &Vec<u8>,
+        root_hash: &[u8],
+        already_verified_ids: &[u8],
     ) -> Result<()>;
 }

--- a/src/share/mod.rs
+++ b/src/share/mod.rs
@@ -34,16 +34,8 @@ pub(crate) trait IsSignedShare: IsShare {
     /// Return the signature itself.
     fn get_signature(&self) -> &Self::Signature;
 
-    /// Verify a given batch of shares are all signed by the same root hash. Returns the root hash
-    /// if verification succeeds, and an `Err` otherwise.
-    fn verify_signatures(shares: &[Self]) -> Result<Vec<u8>>;
-
-    /// Verify the `shares` all have valid signatures from the `root_hash`. Pass a list of shares
-    /// identifiers already verified against this `root_hash`, if any, for better error messaging
-    /// if verification fails.
-    fn continue_verify_signatures(
-        shares: &[Self],
-        root_hash: &[u8],
-        already_verified_ids: &[u8],
-    ) -> Result<()>;
+    /// Verify a given batch of shares are all signed by the same root hash, optionally specifying
+    /// which one using the `root_hash` argument. Returns the root hash if verification succeeds,
+    /// and an `Err` otherwise.
+    fn verify_signatures(shares: &[Self], root_hash: Option<&[u8]>) -> Result<Vec<u8>>;
 }

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -40,6 +40,9 @@ pub(crate) fn validate_shares<S: IsShare>(shares: &Vec<S>) -> Result<(u8, usize)
             share.get_data().len(),
         );
 
+        // Public-facing `Share::share_from_string` performs these three tests, but in case another
+        // type which implements `IsShare` is implemented later that doesn't do that validation,
+        // we'll leave them.
         if id < 1 {
             bail!(ErrorKind::ShareParsingInvalidShareId(id))
         } else if threshold_ < 2 {

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -37,10 +37,6 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
     for share in shares {
         let (id, threshold) = (share.get_id(), share.get_threshold());
 
-        if id > MAX_SHARES {
-            bail!(ErrorKind::ShareIdentifierTooBig(id, MAX_SHARES))
-        }
-
         if id < 1 {
             bail!(ErrorKind::ShareParsingInvalidShareId(id))
         }

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -39,6 +39,8 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
 
         if id < 1 {
             bail!(ErrorKind::ShareParsingInvalidShareId(id))
+        } else if threshold < 2 {
+            bail!(ErrorKind::ShareParsingInvalidShareThreshold(threshold, id))
         }
 
         k_compatibility_sets

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -64,7 +64,6 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
     let k_sets = k_compatibility_sets.keys().count();
 
     match k_sets {
-        0 => bail!(ErrorKind::EmptyShares),
         1 => {} // All shares have the same roothash.
         _ => {
             bail! {

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -91,9 +91,10 @@ pub(crate) fn validate_shares<S: IsShare>(
         let threshold_ = share.get_threshold();
         let slen_ = share.get_data().len();
 
-        // Public-facing `Share::share_from_string` performs these three tests, but in case another
-        // type which implements `IsShare` is implemented later that doesn't do that validation,
-        // we'll leave them.
+        // Public-facing `Share::share_from_string` performs the following three tests, so they are
+        // redudant in production for the time being. However, for our tests, not all shares tested
+        // come from strings (e.g., `dss::ss1::Share` we test by constructing from parts), so they
+        // should be left for now.
         if id < 1 {
             bail!(ErrorKind::ShareParsingInvalidShareId(id))
         } else if threshold_ < 2 {

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -34,11 +34,9 @@ pub(crate) fn validate_shares<S: IsShare>(shares: &Vec<S>) -> Result<(u8, usize)
     let mut slen = 0;
 
     for share in shares {
-        let (id, threshold_, slen_) = (
-            share.get_id(),
-            share.get_threshold(),
-            share.get_data().len(),
-        );
+        let id = share.get_id();
+        let threshold_ = share.get_threshold();
+        let slen_ = share.get_data().len();
 
         // Public-facing `Share::share_from_string` performs these three tests, but in case another
         // type which implements `IsShare` is implemented later that doesn't do that validation,
@@ -75,6 +73,8 @@ pub(crate) fn validate_shares<S: IsShare>(shares: &Vec<S>) -> Result<(u8, usize)
         ids.push(id);
     }
 
+    // Only once the threshold is confirmed as consistent should we determine if shares are
+    // missing.
     if shares_count < threshold as usize {
         bail!(ErrorKind::MissingShares(shares_count, threshold))
     }

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -9,26 +9,26 @@ use share::{IsShare, IsSignedShare};
 
 /// TODO
 pub(crate) fn validate_signed_shares<S: IsSignedShare>(
-    shares: &Vec<S>,
+    shares: &[S],
     verify_signatures: bool,
 ) -> Result<(u8, usize)> {
     let result = validate_shares(shares)?;
 
     if verify_signatures {
-        S::verify_signatures(&shares)?;
+        S::verify_signatures(shares)?;
     };
 
     Ok(result)
 }
 
 pub(crate) fn begin_signed_share_validation<S: IsSignedShare>(
-    shares: &Vec<S>,
+    shares: &[S],
     verify_signatures: bool,
 ) -> Result<(u8, usize, Vec<u8>, Option<Vec<u8>>)> {
     let (threshold, slen, ids) = _validate_shares(shares, None, None, None)?;
 
     let root_hash = if verify_signatures {
-        Some(S::verify_signatures(&shares)?)
+        Some(S::verify_signatures(shares)?)
     } else {
         None
     };
@@ -37,11 +37,11 @@ pub(crate) fn begin_signed_share_validation<S: IsSignedShare>(
 }
 
 pub(crate) fn continue_signed_share_validation<S: IsSignedShare>(
-    shares: &Vec<S>,
-    already_verified_ids: &Vec<u8>,
+    shares: &[S],
+    already_verified_ids: &[u8],
     threshold: u8,
     slen: usize,
-    root_hash: Option<&Vec<u8>>,
+    root_hash: Option<&[u8]>,
 ) -> Result<(Vec<u8>)> {
     let (_, _, new_ids) = _validate_shares(
         shares,
@@ -58,7 +58,7 @@ pub(crate) fn continue_signed_share_validation<S: IsSignedShare>(
 }
 
 /// Validates a full set of shares.
-pub(crate) fn validate_shares<S: IsShare>(shares: &Vec<S>) -> Result<(u8, usize)> {
+pub(crate) fn validate_shares<S: IsShare>(shares: &[S]) -> Result<(u8, usize)> {
     let (threshold, slen, _) = _validate_shares(shares, None, None, None)?;
     let shares_count = shares.len();
     if shares_count < threshold as usize {
@@ -69,10 +69,10 @@ pub(crate) fn validate_shares<S: IsShare>(shares: &Vec<S>) -> Result<(u8, usize)
 
 /// TODO: Doc
 fn _validate_shares<S: IsShare>(
-    shares: &Vec<S>,
+    shares: &[S],
     threshold: Option<u8>,
     slen: Option<usize>,
-    already_verified_ids: Option<&Vec<u8>>,
+    already_verified_ids: Option<&[u8]>,
 ) -> Result<(u8, usize, Vec<u8>)> {
     if shares.is_empty() {
         bail!(ErrorKind::EmptyShares);
@@ -80,7 +80,7 @@ fn _validate_shares<S: IsShare>(
 
     let shares_count = shares.len();
     let mut ids = if already_verified_ids.is_some() {
-        let mut ids = already_verified_ids.unwrap().clone();
+        let mut ids = already_verified_ids.unwrap().to_vec();
         ids.reserve_exact(shares_count);
         ids
     } else {

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -81,7 +81,7 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
     let threshold = k_compatibility_sets.keys().last().unwrap().to_owned();
 
     if shares_count < threshold as usize {
-        bail!(ErrorKind::MissingShares(threshold as usize, shares_count));
+        bail!(ErrorKind::MissingShares(shares_count, threshold as usize));
     }
 
     Ok((threshold, result))

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -67,7 +67,7 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
         1 => {} // All shares have the same roothash.
         _ => {
             bail! {
-                ErrorKind::IncompatibleSets(
+                ErrorKind::IncompatibleThresholds(
                     k_compatibility_sets
                         .values()
                         .map(|x| x.to_owned())

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -55,11 +55,6 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
             bail!(ErrorKind::ShareParsingErrorEmptyShare(id))
         }
 
-        if result.iter().any(|s| s.get_data() == share.get_data()) && share.get_threshold() != 1 {
-            // When threshold = 1, shares data can be the same
-            bail!(ErrorKind::DuplicateShareData(id));
-        }
-
         result.push(share);
     }
 

--- a/src/share/validation.rs
+++ b/src/share/validation.rs
@@ -81,7 +81,7 @@ pub(crate) fn validate_shares<S: IsShare>(shares: Vec<S>) -> Result<(u8, Vec<S>)
     let threshold = k_compatibility_sets.keys().last().unwrap().to_owned();
 
     if shares_count < threshold as usize {
-        bail!(ErrorKind::MissingShares(shares_count, threshold as usize));
+        bail!(ErrorKind::MissingShares(shares_count, threshold));
     }
 
     Ok((threshold, result))

--- a/src/sss/encode.rs
+++ b/src/sss/encode.rs
@@ -6,13 +6,10 @@ use std::io::prelude::*;
 pub(crate) fn encode_secret_byte<W: Write>(src: &[u8], n: u8, w: &mut W) -> io::Result<()> {
     for raw_x in 1..(u16::from(n) + 1) {
         let x = Gf256::from_byte(raw_x as u8);
-        let mut fac = Gf256::one();
-        let mut acc = Gf256::zero();
-        for &coeff in src.iter() {
-            acc += fac * Gf256::from_byte(coeff);
-            fac *= x;
-        }
-        w.write_all(&[acc.to_byte()])?;
+        let sum = src.iter().rev().fold(Gf256::zero(), |acc, &coeff| {
+            Gf256::from_byte(coeff) + acc * x
+        });
+        w.write_all(&[sum.to_byte()])?;
     }
     Ok(())
 }

--- a/src/sss/encode.rs
+++ b/src/sss/encode.rs
@@ -2,7 +2,8 @@ use gf256::Gf256;
 use std::io;
 use std::io::prelude::*;
 
-/// evaluates a polynomial at x=1, 2, 3, ... n (inclusive)
+/// Evaluates a polynomial at x=1, 2, 3, ... n (inclusive) using
+/// Horner's method.
 pub(crate) fn encode_secret_byte<W: Write>(src: &[u8], n: u8, w: &mut W) -> io::Result<()> {
     for raw_x in 1..(u16::from(n) + 1) {
         let x = Gf256::from_byte(raw_x as u8);

--- a/src/sss/format.rs
+++ b/src/sss/format.rs
@@ -49,12 +49,12 @@ pub(crate) fn share_from_string(s: &str, is_signed: bool) -> Result<Share> {
         (k, i, p3)
     };
 
-    if k < 1 || i < 1 {
-        bail! {
-            ErrorKind::ShareParsingError(
-                format!("Found illegal share info: threshold = {}, identifier = {}.", k, i),
-            )
-        }
+    if i < 1 {
+        bail!(ErrorKind::ShareParsingInvalidShareId(i))
+    } else if k < 2 {
+        bail!(ErrorKind::ShareParsingInvalidShareThreshold(k, i))
+    } else if p3.is_empty() {
+        bail!(ErrorKind::ShareParsingErrorEmptyShare(i))
     }
 
     let raw_data = base64::decode_config(p3, BASE64_CONFIG).chain_err(|| {

--- a/src/sss/format.rs
+++ b/src/sss/format.rs
@@ -1,9 +1,9 @@
+use base64;
 use errors::*;
 use merkle_sigs::{MerklePublicKey, Proof, PublicKey};
-use protobuf::{self, Message, RepeatedField};
-use base64;
-use sss::{Share, HASH_ALGO};
 use proto::wrapped::ShareProto;
+use protobuf::{self, Message, RepeatedField};
+use sss::{Share, HASH_ALGO};
 use std::error::Error;
 
 const BASE64_CONFIG: base64::Config = base64::STANDARD_NO_PAD;

--- a/src/sss/mod.rs
+++ b/src/sss/mod.rs
@@ -8,8 +8,8 @@ pub(crate) use self::share::*;
 mod format;
 // pub use self::format::*;
 
-mod scheme;
-pub(crate) use self::scheme::*;
+pub(crate) mod scheme;
+use self::scheme::Recover;
 
 mod encode;
 
@@ -36,8 +36,7 @@ static HASH_ALGO: &'static Algorithm = &SHA512;
 /// }
 /// ```
 pub fn split_secret(k: u8, n: u8, secret: &[u8], sign_shares: bool) -> Result<Vec<String>> {
-    SSS::default()
-        .split_secret(k, n, secret, sign_shares)
+    scheme::split_secret(k, n, secret, sign_shares)
         .map(|shares| shares.into_iter().map(Share::into_string).collect())
 }
 
@@ -65,5 +64,5 @@ pub fn split_secret(k: u8, n: u8, secret: &[u8], sign_shares: bool) -> Result<Ve
 /// ```
 pub fn recover_secret(shares: &[String], verify_signatures: bool) -> Result<Vec<u8>> {
     let shares = Share::parse_all(shares, verify_signatures)?;
-    SSS::recover_secret(shares, verify_signatures)
+    Recover::recover_secret(&shares, verify_signatures)
 }

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -1,121 +1,91 @@
-//! SSS provides Shamir's secret sharing with raw data.
+//! Provides Shamir's secret sharing with raw data.
 
 use merkle_sigs::sign_data_vec;
 use rand::{OsRng, Rng};
 
 use errors::*;
 use lagrange::PartialSecret;
-use share::validation::{begin_partial_signed_share_validation, continue_partial_signed_share_validation,
-                        validate_share_count, validate_signed_shares};
+use share::IsShare;
+use share::validation::{validate_share_count, validate_signed_shares};
 use sss::format::format_share_for_signing;
 use sss::{Share, HASH_ALGO};
 
 use super::encode::encode_secret_byte;
 
-/// SSS provides Shamir's secret sharing with raw data.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct SSS;
+/// Performs threshold k-out-of-n Shamir's secret sharing.
+pub(crate) fn split_secret(
+    threshold: u8,
+    shares_count: u8,
+    secret: &[u8],
+    sign_shares: bool,
+) -> Result<Vec<Share>> {
+    let (threshold, shares_count) = validate_share_count(threshold, shares_count)?;
+    let shares = secret_share(secret, threshold, shares_count)?;
 
-impl SSS {
-    /// Performs threshold k-out-of-n Shamir's secret sharing.
-    pub fn split_secret(
-        &self,
-        threshold: u8,
-        shares_count: u8,
-        secret: &[u8],
-        sign_shares: bool,
-    ) -> Result<Vec<Share>> {
-        let (threshold, shares_count) = validate_share_count(threshold, shares_count)?;
-        let shares = Self::secret_share(secret, threshold, shares_count)?;
+    let signatures = if sign_shares {
+        let shares_to_sign = shares
+            .iter()
+            .enumerate()
+            .map(|(i, x)| format_share_for_signing(threshold, (i + 1) as u8, x))
+            .collect::<Vec<_>>();
 
-        let signatures = if sign_shares {
-            let shares_to_sign = shares
-                .iter()
-                .enumerate()
-                .map(|(i, x)| format_share_for_signing(threshold, (i + 1) as u8, x))
-                .collect::<Vec<_>>();
-
-            let sign = sign_data_vec(&shares_to_sign, HASH_ALGO)
-                .unwrap()
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
-
-            Some(sign)
-        } else {
-            None
-        };
-
-        let sig_pairs = signatures
-            .unwrap_or_else(|| vec![None; shares_count as usize])
+        let sign = sign_data_vec(&shares_to_sign, HASH_ALGO)
+            .unwrap()
             .into_iter()
-            .map(|sig_pair| sig_pair.map(From::from));
+            .map(Some)
+            .collect::<Vec<_>>();
 
-        let shares_and_sigs = shares.into_iter().enumerate().zip(sig_pairs);
+        Some(sign)
+    } else {
+        None
+    };
 
-        let result = shares_and_sigs.map(|((index, data), signature_pair)| {
-            // This is actually safe since we alwaays generate less than 256 shares.
-            let id = (index + 1) as u8;
+    let sig_pairs = signatures
+        .unwrap_or_else(|| vec![None; shares_count as usize])
+        .into_iter()
+        .map(|sig_pair| sig_pair.map(From::from));
 
-            Share {
-                id,
-                threshold,
-                data,
-                signature_pair,
-            }
-        });
+    let shares_and_sigs = shares.into_iter().enumerate().zip(sig_pairs);
 
-        Ok(result.collect())
-    }
+    let result = shares_and_sigs.map(|((index, data), signature_pair)| {
+        // This is actually safe since we alwaays generate less than 256 shares.
+        let id = (index + 1) as u8;
 
-    fn secret_share(src: &[u8], threshold: u8, shares_count: u8) -> Result<Vec<Vec<u8>>> {
-        let mut result = Vec::with_capacity(shares_count as usize);
-        for _ in 0..(shares_count as usize) {
-            result.push(vec![0u8; src.len()]);
+        Share {
+            id,
+            threshold,
+            data,
+            signature_pair,
         }
-        let mut col_in = vec![0u8; threshold as usize];
-        let mut col_out = Vec::with_capacity(shares_count as usize);
-        let mut osrng = OsRng::new()?;
-        for (c, &s) in src.iter().enumerate() {
-            col_in[0] = s;
-            // NOTE: switch to `try_fill_bytes` when it lands in a stable release:
-            // https://github.com/rust-lang-nursery/rand/commit/230b2258dbd99ff8bd991008c972d923d4b5d10c
-            osrng.fill_bytes(&mut col_in[1..]);
-            col_out.clear();
-            encode_secret_byte(&*col_in, shares_count, &mut col_out)?;
-            for (&y, share) in col_out.iter().zip(result.iter_mut()) {
-                share[c] = y;
-            }
-        }
-        Ok(result)
-    }
+    });
 
-    /// Recovers the secret from a k-out-of-n Shamir's secret sharing.
-    ///
-    /// At least `k` distinct shares need to be provided to recover the share.
-    pub fn recover_secret(shares: Vec<Share>, verify_signatures: bool) -> Result<Vec<u8>> {
-        let (threshold, slen) = validate_signed_shares(&shares, verify_signatures)?;
-
-        let mut col_in = Vec::with_capacity(threshold as usize);
-        let mut secret = Vec::with_capacity(slen);
-        for byteindex in 0..slen {
-            col_in.clear();
-            for s in shares.iter().take(threshold as usize) {
-                col_in.push((s.id, s.data[byteindex]));
-            }
-            let secret_byte_computation = PartialSecret::new(threshold, &col_in);
-            // Safe to unwrap because we have already validated we are providing `PartialSecret`
-            // with `threshold` secret bytes in `col_in`.
-            secret.push(secret_byte_computation.get_secret().unwrap());
-        }
-
-        Ok(secret)
-    }
+    Ok(result.collect())
 }
 
-/// `IncrementalRecovery` provides a way to incrementally recover a secret in cases where not all
-/// shares are available at once.
-pub(crate) struct IncrementalRecovery {
+fn secret_share(src: &[u8], threshold: u8, shares_count: u8) -> Result<Vec<Vec<u8>>> {
+    let mut result = Vec::with_capacity(shares_count as usize);
+    for _ in 0..(shares_count as usize) {
+        result.push(vec![0u8; src.len()]);
+    }
+    let mut col_in = vec![0u8; threshold as usize];
+    let mut col_out = Vec::with_capacity(shares_count as usize);
+    let mut osrng = OsRng::new()?;
+    for (c, &s) in src.iter().enumerate() {
+        col_in[0] = s;
+        // NOTE: switch to `try_fill_bytes` when it lands in a stable release:
+        // https://github.com/rust-lang-nursery/rand/commit/230b2258dbd99ff8bd991008c972d923d4b5d10c
+        osrng.fill_bytes(&mut col_in[1..]);
+        col_out.clear();
+        encode_secret_byte(&*col_in, shares_count, &mut col_out)?;
+        for (&y, share) in col_out.iter().zip(result.iter_mut()) {
+            share[c] = y;
+        }
+    }
+    Ok(result)
+}
+
+/// `Recover` provides an interface for recovering a secret.
+pub(crate) struct Recover {
     /// The state of each partially-recovered secret byte.
     partial_secrets: Vec<PartialSecret>,
     /// The ids of the share (varies between 1 and n where n is the total number of generated
@@ -129,29 +99,29 @@ pub(crate) struct IncrementalRecovery {
     root_hash: Option<Vec<u8>>,
 }
 
-impl IncrementalRecovery {
+impl Recover {
+    /// Recovers the secret from a k-out-of-n Shamir's secret sharing.
+    ///
+    /// At least `k` distinct shares need to be provided to recover the share.
+    pub fn recover_secret(shares: &[Share], verify_signatures: bool) -> Result<Vec<u8>> {
+        let recovery = Self::new(shares, verify_signatures)?;
+        recovery.get_secret()
+    }
+
     /// Begins a partial secret recovery.
     pub fn new(shares: &[Share], verify_signatures: bool) -> Result<Self> {
-        let (threshold, slen, ids, root_hash) =
-            begin_partial_signed_share_validation(shares, verify_signatures)?;
+        let (threshold, slen, root_hash) =
+            validate_signed_shares(shares, verify_signatures, None, None, None, None)?;
 
         let mut incremental_recovery = Self {
             partial_secrets: Vec::with_capacity(slen),
-            ids,
+            ids: Vec::with_capacity(threshold as usize),
             threshold,
             slen,
             root_hash,
         };
 
-        let mut col_in = Vec::with_capacity(threshold as usize);
-        for byteindex in 0..slen {
-            col_in.clear();
-            for s in shares.iter().take(threshold as usize) {
-                col_in.push((s.id, s.data[byteindex]));
-            }
-            let partial_secret = PartialSecret::new(threshold, &col_in);
-            incremental_recovery.partial_secrets.push(partial_secret);
-        }
+        incremental_recovery.process_shares(shares);
 
         Ok(incremental_recovery)
     }
@@ -159,56 +129,69 @@ impl IncrementalRecovery {
     /// Contines a partial secret recovery.
     pub fn update(&mut self, shares: &[Share]) -> Result<()> {
         if self.root_hash.is_some() {
-            let root_hash = self.root_hash.clone().unwrap();
-            self.ids = continue_partial_signed_share_validation(
+            validate_signed_shares(
                 shares,
-                &self.ids,
-                self.threshold,
-                self.slen,
-                Some(&root_hash),
+                true,
+                Some(self.threshold),
+                Some(self.slen),
+                Some(&self.ids),
+                Some(&self.root_hash.clone().unwrap()),
             )?;
         } else {
-            self.ids = continue_partial_signed_share_validation(
+            validate_signed_shares(
                 shares,
-                &self.ids,
-                self.threshold,
-                self.slen,
+                false,
+                Some(self.threshold),
+                Some(self.slen),
+                Some(&self.ids),
                 None,
             )?;
         }
 
-        let mut col_in = Vec::with_capacity(self.threshold as usize);
+        self.process_shares(shares);
+        Ok(())
+    }
+
+    fn process_shares(&mut self, shares: &[Share]) {
+        let is_new_computation = self.shares_interpolated() == 0;
+        let shares_needed = self.shares_needed() as usize;
+
         for byteindex in 0..self.slen {
-            col_in.clear();
-            for s in shares.iter().take(self.shares_needed() as usize) {
-                col_in.push((s.id, s.data[byteindex]));
+            let col_in: Vec<(u8, u8)> = shares
+                .iter()
+                .take(shares_needed)
+                .map(|s| (s.id, s.data[byteindex]))
+                .collect();
+            if is_new_computation {
+                self.partial_secrets
+                    .push(PartialSecret::new(self.threshold, &col_in));
+            } else {
+                self.partial_secrets[byteindex].update(&col_in);
             }
-            self.partial_secrets[byteindex].update(&col_in);
         }
 
-        Ok(())
+        self.ids.extend(shares.iter().take(shares_needed).map(|s| s.get_id()));
     }
 
     /// Used to determine how many more shares are needed to finish computing a partial secret.
     pub fn shares_interpolated(&self) -> u8 {
-        // Safe indexing because `PartialSecret::new` ensures `self.partial_secrets` will be of
-        // length at least 1.
-        self.partial_secrets[0].shares_interpolated()
+        // Safe cast because validation ensures `self.ids.len() < 255`.
+        self.ids.len() as u8
     }
 
     /// Used to determine how many more shares are needed to finish computing a partial secret.
     pub fn shares_needed(&self) -> u8 {
-        // Safe indexing because `PartialSecret::new` ensures `self.partial_secrets` will be of
-        // length at least 1.
-        self.partial_secrets[0].shares_needed()
+        // Safe unsigned subraction because `process_shares` ensures we never interpolate more than
+        // `threshold`.
+        self.threshold - self.shares_interpolated()
     }
 
     /// Used to obtain the resulting secret when `threshold` shares have been evaluated.
     pub fn get_secret(&self) -> Result<Vec<u8>> {
         if self.shares_needed() != 0 {
-            bail!(ErrorKind::PartialInterpolationNotComplete(
-                self.threshold,
-                self.shares_interpolated()
+            bail!(ErrorKind::MissingShares(
+                self.shares_interpolated(),
+                self.threshold
             ))
         }
         // Safe to unwrap because we already confirmed no more shares are needed.

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -1,13 +1,26 @@
 //! SSS provides Shamir's secret sharing with raw data.
 
+<<<<<<< HEAD
+=======
+use std::cmp::min;
+
+use rand::{OsRng, Rng};
+>>>>>>> Add sample sss module partial secret recovery fns
 use merkle_sigs::sign_data_vec;
 use rand::{OsRng, Rng};
 
 use errors::*;
+<<<<<<< HEAD
 use lagrange::interpolate_at;
 use share::validation::{validate_share_count, validate_signed_shares};
 use sss::format::format_share_for_signing;
 use sss::{Share, HASH_ALGO};
+=======
+use sss::{Share, HASH_ALGO};
+use sss::format::format_share_for_signing;
+use share::validation::{validate_share_count, validate_signed_shares};
+use lagrange::{interpolate_at, PartialSecret};
+>>>>>>> Add sample sss module partial secret recovery fns
 
 use super::encode::encode_secret_byte;
 
@@ -107,5 +120,103 @@ impl SSS {
         }
 
         Ok(secret)
+    }
+
+    /// Begins a partial secret recovery.
+    pub fn begin_partial_secret_recovery(
+        shares: Vec<Share>,
+        verify_signatures: bool,
+    ) -> Result<Vec<PartialSecret>> {
+        if shares.is_empty() {
+            bail!(ErrorKind::EmptyShares);
+        }
+
+        let (threshold, shares) = validate_signed_shares(shares, verify_signatures)?;
+
+        let slen = shares[0].data.len();
+        let mut col_in = Vec::with_capacity(min(shares.len(), threshold as usize));
+        let mut partial_secret = Vec::with_capacity(slen);
+        for byteindex in 0..slen {
+            col_in.clear();
+            for s in shares.iter().take(threshold as usize) {
+                col_in.push((s.id, s.data[byteindex]));
+            }
+            let partial_secret_byte = PartialSecret::new(threshold, &*col_in)?;
+            partial_secret.push(partial_secret_byte);
+        }
+
+        Ok(partial_secret)
+    }
+
+    /// Contines a partial secret recovery.
+    pub fn update_partial_secret(
+        partial_secret: &mut Vec<PartialSecret>,
+        shares: Vec<Share>,
+        verify_signatures: bool,
+    ) -> Result<()> {
+        if shares.is_empty() {
+            bail!(ErrorKind::EmptyShares);
+        } else if partial_secret.is_empty() {
+            bail!(ErrorKind::EmptyShares);
+        }
+        let threshold = partial_secret[0].threshold;
+        let shares_evaluated = partial_secret[0].shares_evaluated();
+        let shares_needed = partial_secret[0].shares_needed();
+        if shares_needed == 0 {
+            bail!(ErrorKind::InvalidShareCountMax(
+                (shares.len() + shares_evaluated) as u8,
+                threshold
+            ));
+        } else if shares.is_empty() {
+            bail!(ErrorKind::EmptyShares);
+        } else if shares_evaluated + shares.len() > MAX_SHARES as usize {
+            bail!(ErrorKind::InvalidShareCountMax(
+                (shares_evaluated + shares.len()) as u8,
+                MAX_SHARES
+            ));
+        }
+
+        let (threshold2, shares) = validate_signed_shares(shares, verify_signatures)?;
+        if threshold != threshold2 {
+            bail!(ErrorKind::InconsistentShares)
+        }
+
+        let slen = shares[0].data.len();
+        let mut col_in = Vec::with_capacity(shares_needed);
+        for byteindex in 0..slen {
+            col_in.clear();
+            for s in shares.iter().take(shares_needed) {
+                col_in.push((s.id, s.data[byteindex]));
+            }
+            partial_secret[byteindex].update(&*col_in)?;
+        }
+
+        Ok(())
+    }
+
+    /// Used to determine how many more shares are needed to finish computing a partial secret.
+    pub fn partial_secret_shares_needed(partial_secret: &Vec<PartialSecret>) -> Result<u8> {
+        if partial_secret.is_empty() {
+            bail!(ErrorKind::EmptyShares);
+        }
+        Ok(partial_secret[0].shares_needed() as u8)
+    }
+
+    /// Used to obtain the resulting secret when `threshold` shares have been evaluated.
+    pub fn get_final_secret(partial_secret: &Vec<PartialSecret>) -> Result<Vec<u8>> {
+        if partial_secret.is_empty() {
+            bail!(ErrorKind::EmptyShares);
+        }
+        let threshold = partial_secret[0].threshold;
+        let shares_evaluated = partial_secret[0].shares_evaluated();
+        let shares_needed = partial_secret[0].shares_needed();
+        if shares_needed != 0 {
+            bail!(ErrorKind::MissingShares(
+                shares_evaluated,
+                threshold as usize
+            ));
+        }
+        // Safe to unwrap because we already confirmed no more shares are needed.
+        Ok(partial_secret.iter().map(|ps| ps.secret.unwrap()).collect())
     }
 }

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -1,13 +1,13 @@
 //! SSS provides Shamir's secret sharing with raw data.
 
-use rand::{OsRng, Rng};
 use merkle_sigs::sign_data_vec;
+use rand::{OsRng, Rng};
 
 use errors::*;
-use sss::{Share, HASH_ALGO};
-use sss::format::format_share_for_signing;
-use share::validation::{validate_share_count, validate_signed_shares};
 use lagrange::interpolate_at;
+use share::validation::{validate_share_count, validate_signed_shares};
+use sss::format::format_share_for_signing;
+use sss::{Share, HASH_ALGO};
 
 use super::encode::encode_secret_byte;
 

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -77,6 +77,8 @@ impl SSS {
         let mut osrng = OsRng::new()?;
         for (c, &s) in src.iter().enumerate() {
             col_in[0] = s;
+            // NOTE: switch to `try_fill_bytes` when it lands in a stable release:
+            // https://github.com/rust-lang-nursery/rand/commit/230b2258dbd99ff8bd991008c972d923d4b5d10c
             osrng.fill_bytes(&mut col_in[1..]);
             col_out.clear();
             encode_secret_byte(&*col_in, shares_count, &mut col_out)?;

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -129,9 +129,9 @@ pub(crate) struct IncrementalRecovery {
 
 impl IncrementalRecovery {
     /// Begins a partial secret recovery.
-    pub fn new(shares: Vec<Share>, verify_signatures: bool) -> Result<Self> {
+    pub fn new(shares: &[Share], verify_signatures: bool) -> Result<Self> {
         let (threshold, slen, ids, root_hash) =
-            begin_signed_share_validation(&shares, verify_signatures)?;
+            begin_signed_share_validation(shares, verify_signatures)?;
 
         let mut incremental_recovery = Self {
             partial_secrets: Vec::with_capacity(slen),
@@ -155,11 +155,11 @@ impl IncrementalRecovery {
     }
 
     /// Contines a partial secret recovery.
-    pub fn update(&mut self, shares: Vec<Share>) -> Result<()> {
+    pub fn update(&mut self, shares: &[Share]) -> Result<()> {
         if self.root_hash.is_some() {
             let root_hash = self.root_hash.clone().unwrap();
             self.ids = continue_signed_share_validation(
-                &shares,
+                shares,
                 &self.ids,
                 self.threshold,
                 self.slen,
@@ -167,7 +167,7 @@ impl IncrementalRecovery {
             )?;
         } else {
             self.ids = continue_signed_share_validation(
-                &shares,
+                shares,
                 &self.ids,
                 self.threshold,
                 self.slen,

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -5,7 +5,7 @@ use rand::{OsRng, Rng};
 
 use errors::*;
 use lagrange::PartialSecret;
-use share::validation::{begin_signed_share_validation, continue_signed_share_validation,
+use share::validation::{begin_partial_signed_share_validation, continue_partial_signed_share_validation,
                         validate_share_count, validate_signed_shares};
 use sss::format::format_share_for_signing;
 use sss::{Share, HASH_ALGO};
@@ -133,7 +133,7 @@ impl IncrementalRecovery {
     /// Begins a partial secret recovery.
     pub fn new(shares: &[Share], verify_signatures: bool) -> Result<Self> {
         let (threshold, slen, ids, root_hash) =
-            begin_signed_share_validation(shares, verify_signatures)?;
+            begin_partial_signed_share_validation(shares, verify_signatures)?;
 
         let mut incremental_recovery = Self {
             partial_secrets: Vec::with_capacity(slen),
@@ -160,7 +160,7 @@ impl IncrementalRecovery {
     pub fn update(&mut self, shares: &[Share]) -> Result<()> {
         if self.root_hash.is_some() {
             let root_hash = self.root_hash.clone().unwrap();
-            self.ids = continue_signed_share_validation(
+            self.ids = continue_partial_signed_share_validation(
                 shares,
                 &self.ids,
                 self.threshold,
@@ -168,7 +168,7 @@ impl IncrementalRecovery {
                 Some(&root_hash),
             )?;
         } else {
-            self.ids = continue_signed_share_validation(
+            self.ids = continue_partial_signed_share_validation(
                 shares,
                 &self.ids,
                 self.threshold,

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -153,14 +153,10 @@ impl Recover {
         let ub = min(self.shares_needed() as usize, shares.len());
         let shares = &shares[..ub];
         let is_new_computation = self.shares_interpolated() == 0;
-        self.ids
-            .extend(shares.iter().map(|s| Gf256::from_byte(s.id)));
+        self.ids.extend(shares.iter().map(|s| gf256!(s.id)));
 
         for byteindex in 0..self.slen {
-            let ys: Vec<Gf256> = shares
-                .iter()
-                .map(|s| Gf256::from_byte(s.data[byteindex]))
-                .collect();
+            let ys: Vec<Gf256> = shares.iter().map(|s| gf256!(s.data[byteindex])).collect();
             if is_new_computation {
                 self.partial_secrets
                     .push(PartialSecret::new(self.threshold, &self.ids, &ys));

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -8,7 +8,6 @@ use rand::{OsRng, Rng};
 use errors::*;
 use gf256::Gf256;
 use lagrange::{evaluate_at_zero, BarycentricWeights};
-use share::IsShare;
 use share::validation::*;
 use sss::format::format_share_for_signing;
 use sss::{Share, HASH_ALGO};

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -102,7 +102,8 @@ impl SSS {
             for s in shares.iter().take(threshold as usize) {
                 col_in.push((s.id, s.data[byteindex]));
             }
-            secret.push(interpolate_at(&*col_in));
+            let secret_byte = interpolate_at(threshold, &*col_in)?;
+            secret.push(secret_byte);
         }
 
         Ok(secret)

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -102,7 +102,7 @@ impl SSS {
             for s in shares.iter().take(threshold as usize) {
                 col_in.push((s.id, s.data[byteindex]));
             }
-            secret.push(interpolate_at(threshold, &*col_in));
+            secret.push(interpolate_at(&*col_in));
         }
 
         Ok(secret)

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -93,9 +93,8 @@ impl SSS {
     ///
     /// At least `k` distinct shares need to be provided to recover the share.
     pub fn recover_secret(shares: Vec<Share>, verify_signatures: bool) -> Result<Vec<u8>> {
-        let (threshold, shares) = validate_signed_shares(shares, verify_signatures)?;
+        let (threshold, slen) = validate_signed_shares(&shares, verify_signatures)?;
 
-        let slen = shares[0].data.len();
         let mut col_in = Vec::with_capacity(threshold as usize);
         let mut secret = Vec::with_capacity(slen);
         for byteindex in 0..slen {

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -128,6 +128,10 @@ impl Recover {
 
     /// Contines a partial secret recovery.
     pub fn update(&mut self, shares: &[Share]) -> Result<()> {
+        if self.shares_needed() == 0 {
+            bail!(ErrorKind::NoMoreSharesNeeded(self.threshold))
+        }
+
         validate_additional_signed_shares(
             shares,
             Some(self.threshold),

--- a/src/sss/scheme.rs
+++ b/src/sss/scheme.rs
@@ -101,7 +101,7 @@ impl SSS {
             for s in shares.iter().take(threshold as usize) {
                 col_in.push((s.id, s.data[byteindex]));
             }
-            secret.push(interpolate_at(&*col_in));
+            secret.push(interpolate_at(threshold, &*col_in));
         }
 
         Ok(secret)

--- a/src/sss/share.rs
+++ b/src/sss/share.rs
@@ -1,8 +1,8 @@
-use std::error::Error;
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
 
-use merkle_sigs::{MerklePublicKey, Proof};
 use merkle_sigs::verify_data_vec_signature;
+use merkle_sigs::{MerklePublicKey, Proof};
 
 use errors::*;
 use share::{IsShare, IsSignedShare};

--- a/src/sss/share.rs
+++ b/src/sss/share.rs
@@ -95,8 +95,8 @@ impl IsSignedShare for Share {
     // verified against that root hash (if any).
     fn continue_verify_signatures(
         shares: &[Self],
-        root_hash: &Vec<u8>,
-        already_verified_ids: &Vec<u8>,
+        root_hash: &[u8],
+        already_verified_ids: &[u8],
     ) -> Result<()> {
         Self::_verify_signatures(shares, Some(root_hash), Some(already_verified_ids))?;
         Ok(())
@@ -114,19 +114,19 @@ impl IsSignedShare for Share {
 impl Share {
     fn _verify_signatures(
         shares: &[Self],
-        root_hash: Option<&Vec<u8>>,
-        already_verified_ids: Option<&Vec<u8>>,
+        root_hash: Option<&[u8]>,
+        already_verified_ids: Option<&[u8]>,
     ) -> Result<Vec<u8>> {
         let shares_count = shares.len();
         let mut root_hash = if root_hash.is_some() {
-            root_hash.unwrap().clone()
+            root_hash.unwrap().to_vec()
         } else {
             vec![]
         };
         let mut ids = if already_verified_ids.is_some() {
-            let mut ids_ = already_verified_ids.unwrap().clone();
-            ids_.reserve_exact(shares_count);
-            ids_
+            let mut ids = already_verified_ids.unwrap().to_vec();
+            ids.reserve_exact(shares_count);
+            ids
         } else {
             Vec::with_capacity(shares_count)
         };
@@ -145,7 +145,7 @@ impl Share {
             verify_data_vec_signature(
                 format_share_for_signing(share.threshold, share.id, share.data.as_slice()),
                 &(signature.to_vec(), proof.clone()),
-                &root_hash_,
+                root_hash_,
             ).map_err(|e| ErrorKind::InvalidSignature(share.id, String::from(e.description())))?;
 
             if root_hash.is_empty() {

--- a/src/wrapped_secrets/scheme.rs
+++ b/src/wrapped_secrets/scheme.rs
@@ -1,8 +1,8 @@
 use errors::*;
+use proto::VersionProto;
+use proto::wrapped::SecretProto;
 use protobuf;
 use protobuf::Message;
-use proto::wrapped::SecretProto;
-use proto::VersionProto;
 
 use sss::SSS;
 pub(crate) use sss::Share;

--- a/src/wrapped_secrets/scheme.rs
+++ b/src/wrapped_secrets/scheme.rs
@@ -4,8 +4,8 @@ use proto::wrapped::SecretProto;
 use protobuf;
 use protobuf::Message;
 
-use sss::SSS;
 pub(crate) use sss::Share;
+use sss::scheme::*;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct WrappedSecrets;
@@ -30,14 +30,14 @@ impl WrappedSecrets {
 
         let data = rusty_secret.write_to_bytes().unwrap();
 
-        SSS::default().split_secret(k, n, data.as_slice(), sign_shares)
+        split_secret(k, n, data.as_slice(), sign_shares)
     }
 
     /// Recovers the secret from a k-out-of-n Shamir's secret sharing.
     ///
     /// At least `k` distinct shares need to be provided to recover the share.
     pub fn recover_secret(shares: Vec<Share>, verify_signatures: bool) -> Result<SecretProto> {
-        let secret = SSS::recover_secret(shares, verify_signatures)?;
+        let secret = Recover::recover_secret(&shares, verify_signatures)?;
 
         protobuf::parse_from_bytes::<SecretProto>(secret.as_slice())
             .chain_err(|| ErrorKind::SecretDeserializationError)

--- a/tests/recovery_errors.rs
+++ b/tests/recovery_errors.rs
@@ -67,6 +67,17 @@ fn test_recover_duplicate_shares_number() {
 }
 
 #[test]
+#[should_panic(expected = "IncompatibleDataLengths")]
+fn test_recover_incompatible_data_lengths() {
+    let share1 = "2-1-CgnlCxRNtnkzENE".to_string();
+    let share2 = "2-2-ChbG46L1zRszs0PPn63XnnupmZTcgYJ3".to_string();
+
+    let shares = vec![share1, share2];
+
+    recover_secret(&shares, false).unwrap();
+}
+
+#[test]
 #[should_panic(expected = "MissingShares")]
 fn test_recover_too_few_shares() {
     let share1 = "3-1-ChbcCdSZOaMn6DM1jFca2P6/0WRlP7AK".to_string();

--- a/tests/recovery_errors.rs
+++ b/tests/recovery_errors.rs
@@ -67,10 +67,21 @@ fn test_recover_duplicate_shares_number() {
 }
 
 #[test]
-#[should_panic(expected = "IncompatibleDataLengths")]
-fn test_recover_incompatible_data_lengths() {
+#[should_panic(expected = "InconsistentSecretLengths")]
+fn test_recover_inconsistent_secret_lengths() {
     let share1 = "2-1-CgnlCxRNtnkzENE".to_string();
     let share2 = "2-2-ChbG46L1zRszs0PPn63XnnupmZTcgYJ3".to_string();
+
+    let shares = vec![share1, share2];
+
+    recover_secret(&shares, false).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "InconsistentThresholds")]
+fn test_inconsistent_thresholds() {
+    let share1 = "2-1-CgnlCxRNtnkzENE".to_string();
+    let share2 = "3-2-CgkAnUgP3lfwjyM".to_string();
 
     let shares = vec![share1, share2];
 

--- a/tests/recovery_errors.rs
+++ b/tests/recovery_errors.rs
@@ -67,17 +67,6 @@ fn test_recover_duplicate_shares_number() {
 }
 
 #[test]
-#[should_panic(expected = "DuplicateShareData")]
-fn test_recover_duplicate_shares_data() {
-    let share1 = "2-1-CgnlCxRNtnkzENE".to_string();
-    let share2 = "2-2-CgnlCxRNtnkzENE".to_string();
-
-    let shares = vec![share1, share2];
-
-    recover_secret(&shares, false).unwrap();
-}
-
-#[test]
 #[should_panic(expected = "MissingShares")]
 fn test_recover_too_few_shares() {
     let share1 = "3-1-ChbcCdSZOaMn6DM1jFca2P6/0WRlP7AK".to_string();

--- a/tests/recovery_errors.rs
+++ b/tests/recovery_errors.rs
@@ -77,6 +77,17 @@ fn test_recover_too_few_shares() {
     recover_secret(&shares, false).unwrap();
 }
 
+#[test]
+#[should_panic(expected = "ShareParsingInvalidShareThreshold")]
+fn test_recover_invalid_share_threshold() {
+    let share1 = "1-1-CgnlCxRNtnkzENE".to_string();
+    let share2 = "1-1-CgkAnUgP3lfwjyM".to_string();
+
+    let shares = vec![share1, share2];
+
+    recover_secret(&shares, false).unwrap();
+}
+
 // See https://github.com/SpinResearch/RustySecrets/issues/43
 #[test]
 fn test_recover_too_few_shares_bug() {

--- a/tests/recovery_errors.rs
+++ b/tests/recovery_errors.rs
@@ -12,6 +12,13 @@ fn test_recover_no_shares() {
 }
 
 #[test]
+#[should_panic(expected = "ShareParsingErrorEmptyShare")]
+fn test_share_parsing_error_empty_share() {
+    let shares = vec!["2-1-".to_string()];
+    recover_secret(&shares, false).unwrap();
+}
+
+#[test]
 #[should_panic(expected = "ShareParsingError")]
 fn test_recover_2_parts_share() {
     let share1 = "2-1-CgmKQZHMO+5n5pU".to_string();
@@ -34,13 +41,9 @@ fn test_recover_incorrect_share_num() {
 }
 
 #[test]
-#[should_panic(expected = "ShareParsingError")]
+#[should_panic(expected = "ShareParsingInvalidShareId")]
 fn test_recover_0_share_num() {
-    let share1 = "2-0-1YAYwmOHqZ69jA".to_string();
-    let share2 = "2-1-YJZQDGm22Y77Gw".to_string();
-
-    let shares = vec![share1, share2];
-
+    let shares = vec!["2-0-1YAYwmOHqZ69jA".to_string()];
     recover_secret(&shares, false).unwrap();
 }
 

--- a/tests/ss1_recovery_errors.rs
+++ b/tests/ss1_recovery_errors.rs
@@ -136,32 +136,6 @@ fn test_recover_duplicate_shares_number() {
 }
 
 #[test]
-#[should_panic(expected = "DuplicateShareData")]
-fn test_recover_duplicate_shares_data() {
-    let hash = get_test_hash();
-    let share1 = Share {
-        id: 1,
-        threshold: TEST_THRESHOLD,
-        shares_count: TEST_SHARES_COUNT,
-        data: "1YAYwmOHqZ69jA".to_string().into_bytes(),
-        hash: hash.clone(),
-        metadata: None,
-    };
-    let share2 = Share {
-        id: 2,
-        threshold: TEST_THRESHOLD,
-        shares_count: TEST_SHARES_COUNT,
-        data: "1YAYwmOHqZ69jA".to_string().into_bytes(),
-        hash: hash.clone(),
-        metadata: None,
-    };
-
-    let shares = vec![share1, share2];
-
-    recover_secret(&shares).unwrap();
-}
-
-#[test]
 #[should_panic(expected = "MissingShares")]
 fn test_recover_too_few_shares() {
     let hash = get_test_hash();

--- a/tests/test_vectors.rs
+++ b/tests/test_vectors.rs
@@ -62,7 +62,7 @@ fn test_recover_es_test_vectors() {
 }
 
 #[test]
-fn test_recover_sellibitze_more_than_threshold_shars() {
+fn test_recover_sellibitze_more_than_threshold_shares() {
     let share1 = "2-1-1YAYwmOHqZ69jA";
     let share2 = "2-4-F7rAjX3UOa53KA";
     let share3 = "2-2-YJZQDGm22Y77Gw";

--- a/tests/thss_recovery_errors.rs
+++ b/tests/thss_recovery_errors.rs
@@ -107,29 +107,6 @@ fn test_recover_duplicate_shares_number() {
 }
 
 #[test]
-#[should_panic(expected = "DuplicateShareData")]
-fn test_recover_duplicate_shares_data() {
-    let share1 = Share {
-        id: 1,
-        threshold: 2,
-        shares_count: 2,
-        data: "1YAYwmOHqZ69jA".to_string().into_bytes(),
-        metadata: None,
-    };
-    let share2 = Share {
-        id: 2,
-        threshold: 2,
-        shares_count: 2,
-        data: "1YAYwmOHqZ69jA".to_string().into_bytes(),
-        metadata: None,
-    };
-
-    let shares = vec![share1, share2];
-
-    recover_secret(&shares).unwrap();
-}
-
-#[test]
 #[should_panic(expected = "MissingShares")]
 fn test_recover_too_few_shares() {
     let share1 = Share {


### PR DESCRIPTION
### Status

Having shown an earlier version of this branch to @romac, I'm now putting this up for public review. It is still a work in progress, but the main components are in place.

### Description

This PR implements most of a complete interface for incrementally computing a secret using barycentric Lagrange interpolation. In cases where not all shares are available at once, it is still possible to start interpolating the secret polynomial, such that when threshold shares are finally present, the final computation time (i.e., the time between receiving the threshold-th share and the secret being recovered) is much smaller. This will be especially noticeable when the secret is very long, or the threshold is very high. (E.g., in Sunder, shares are entered one at a time and this could be useful.)

It is still missing it's highest-level, public-facing interface that would accept `&[String]`s (shares in string form), parse them, and return `Recovery` objects. `Recovery` objects store and update the state of the partially recovered secret.

Under the hood, `Recovery` objects store:

1. `barycentric` weights and diffs computed evaluate the polynomial.
2. The `ids` processed so far.
3. The `threshold`.
4. The secret length (`slen`).
5. Optionally, the `root_hash` of the Merkle tree (i.e., the public key the shares were signed with).
6. Optionally, the `secret`.

1-3 are needed to correctly compute the secret, and know when it's ready. Since there would be a lot of redundant data among the `BarycentricWeights`s if we were to store the `ids` and `threshold` in that struct, we depend on `Recovery` to store and update the `ids`, and provide new points to update each `BarycentricWeights`. When `threshold` shares have been processed, the `secret`, which is initialized at `None`, is automatically computed (`Some<Vec<u8>>`), and can then be retrieved with `get_secret`.

2-5 are needed for validation of the shares and verification of the signatures. If `verify_signatures` is true `Recovery::new()` will set the the `root_hash` to the root hash of the initial share(s) used to create the `Recovery` object, and this `root_hash` value is automatically used during subsequent `Recover::update`s to ensure consistency among the signatures. Likewise, during updates share validation "picks up where it left off" by passing the already processed `ids`, along with the new shares to be validate, to the new function `validate_additional_signed_shares` in order to prevent duplicate shares from being processed.

### Thoughts/ ideas:

I'm not sure if it is necessary to create `{to,from}_string` methods for `Recovery` in order to make a functional interface in regards to the node library. If it is not necessary, I assume this means the node interface can act on an `Recovery` object in memory, without it having to be in a printable or JS-intelligible/interoperable form. In this case, one could simply wait until threshold shares have been interpolated, and then call `get_secret()` on the `Recovery` object, which will return a `Result<Vec<u8>>` (just as does `Recovery::recover_secret`, which, though changed under the hood, provides the same interface that `SSS::recover_secret` used to).

Whether or not it such methods are necessary, they may be useful. The idea being that you could partially interpolate a secret from less than threshold shares, storing a result a fraction of the size the combined shares (and maybe more importantly/ conveniently, as a single piece of data), and then later interpolate more shares to get the final result. To do this we'd need some way to serialize an `Recovery` for long-term storage (string, or binary for that matter). As a use case, imagine you want to recover a secret using Sunder, and you expect to get shares in person over the course of some time. A useful feature would be the ability to save to disk a serialized `Recovery` object, so that you don't have to save each share to disk, and then enter them all in once there are sufficient. Good UI would keep you updated on how many shares you've interpolated so far and how many more are needed to fully recover the object using the `shares_interpolated()` and `shares_needed()` methods. Especially when recovering multiple secrets at a time in an incremental effort, a good UI built around this functionality could save you a lot of organizational effort and help prevent mistakes.

### TODO
- Improve documentation and code comments.
- Add a lot more tests.
- Add a few more benchmarks.
- Create highest-level (user) interface that takes `&[String]`.
  -  Protobuf/ `{to,from_string}` for `Recovery`?
- Catch and modify any `InconsistentSignature` errors to correct the `ids` argument when `S::verify_signature` is called in `validate::validate_additional_signed_shares` before re-raising (or whatever the Rustaceans call this) with `match` and whatever else from the `error_chain` crate (see [this commit message](https://github.com/SpinResearch/RustySecrets/pull/61/commits/dc8b436fcc365adf93d750d199ebb5a0d92f071f)).